### PR TITLE
Make LintTasks declared in external build scripts safe by applying convention without dependency on extension def in scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Available on the Gradle Plugins Portal: https://plugins.gradle.org/plugin/org.jm
 
 ```groovy
 plugins {
-    id 'org.jmailen.kotlinter' version '0.7.0'
+    id 'org.jmailen.kotlinter' version '0.8.1'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     testCompile 'junit:junit:4.12'
 }
 
-version = '0.8.0'
+version = '0.8.1'
 group = 'org.jmailen.gradle'
 def pluginId = 'org.jmailen.kotlinter'
 

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterPlugin.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterPlugin.kt
@@ -12,13 +12,17 @@ import org.jmailen.gradle.kotlinter.tasks.LintTask
 
 class KotlinterPlugin : Plugin<Project> {
 
-    override fun apply(project: Project?) {
-        project?.let { p ->
-            p.extensions.create("kotlinter", KotlinterExtension::class.java)
+    override fun apply(project: Project) {
+        val kotlinterExtention = project.extensions.create("kotlinter", KotlinterExtension::class.java)
 
-            // for known kotlin plugins, create tasks by convention.
-            p.plugins.withId("org.jetbrains.kotlin.jvm") {
-                KotlinterApplier(p).createTasks(p.kotlinSourceSets())
+        // for known kotlin plugins, create tasks by convention.
+        project.plugins.withId("org.jetbrains.kotlin.jvm") {
+            KotlinterApplier(project).createTasks(project.kotlinSourceSets())
+        }
+
+        project.afterEvaluate {
+            project.tasks.withType(LintTask::class.java) { lintTask ->
+                lintTask.ignoreFailures = kotlinterExtention.ignoreFailures
             }
         }
     }

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/LintTask.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/LintTask.kt
@@ -19,8 +19,7 @@ open class LintTask : SourceTask() {
     lateinit var report: File
 
     @Input
-    fun ignoreFailures() =
-            project.extensions.getByType(KotlinterExtension::class.java).ignoreFailures
+    var ignoreFailures = false
 
     @TaskAction
     fun run() {
@@ -50,7 +49,7 @@ open class LintTask : SourceTask() {
 
         if (errors.isNotEmpty()) {
             report.writeText(errors)
-            if (!ignoreFailures()) {
+            if (!ignoreFailures) {
                 throw GradleException("Kotlin source failed lint check.")
             }
         } else {


### PR DESCRIPTION
Should address #3 