### PR TITLE
Allow the indent size to be configured

### DIFF
--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterExtension.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterExtension.kt
@@ -4,4 +4,6 @@ open class KotlinterExtension {
 
     /** Don't fail build on lint issues */
     var ignoreFailures = false
+
+    var indentSize = 4
 }

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterPlugin.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterPlugin.kt
@@ -34,6 +34,7 @@ class KotlinterPlugin : Plugin<Project> {
         project.afterEvaluate {
             project.tasks.withType(LintTask::class.java) { lintTask ->
                 lintTask.ignoreFailures = kotlinterExtention.ignoreFailures
+                lintTask.indentSize = kotlinterExtention.indentSize
             }
         }
     }

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/LintTask.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/LintTask.kt
@@ -21,6 +21,9 @@ open class LintTask : SourceTask() {
     @Input
     var ignoreFailures = false
 
+    @Input
+    var indentSize = 4
+
     @TaskAction
     fun run() {
         var errors = ""
@@ -58,7 +61,7 @@ open class LintTask : SourceTask() {
     }
 
     private fun lintKt(file: File, ruleSets: List<RuleSet>, onError: (line: Int, col: Int, detail: String) -> Unit) {
-        KtLint.lint(file.readText(), ruleSets) { error ->
+        KtLint.lint(file.readText(), ruleSets, mapOf("indent_size" to indentSize.toString())) { error ->
             onError(error.line, error.col, error.detail)
         }
     }


### PR DESCRIPTION
ktlint allows the indent size to be configured by passing a map of user data in to the lint method. This PR hooks into that mechanism. This allows 

```groovy
kotlinter {
  indentSize = 2
}
```
