### PR TITLE
update ktlint version and add support for continuation_indent_size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ out
 *.ipr
 *.iml
 TODO.md
+.idea

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.github.shyiko:ktlint:0.12.1'
+    compile 'com.github.shyiko:ktlint:0.13.0'
     compileOnly 'org.jetbrains.kotlin:kotlin-gradle-plugin'
     compileOnly 'com.android.tools.build:gradle:2.3.3'
     testCompile 'junit:junit:4.12'

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterExtension.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterExtension.kt
@@ -4,6 +4,7 @@ open class KotlinterExtension {
     companion object {
         const val DEFAULT_IGNORE_FAILURES = false
         const val DEFAULT_INDENT_SIZE = 4
+        const val DEFAULT_CONTINUATION_INDENT_SIZE = 8
         val DEFAULT_REPORTER = ReporterType.checkstyle.name
     }
 
@@ -11,6 +12,8 @@ open class KotlinterExtension {
     var ignoreFailures = DEFAULT_IGNORE_FAILURES
 
     var indentSize = DEFAULT_INDENT_SIZE
+
+    var continuationIndentSize = DEFAULT_CONTINUATION_INDENT_SIZE
 
     var reporter: String? = null
 

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterPlugin.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterPlugin.kt
@@ -35,12 +35,14 @@ class KotlinterPlugin : Plugin<Project> {
             project.tasks.withType(LintTask::class.java) { lintTask ->
                 lintTask.ignoreFailures = kotlinterExtention.ignoreFailures
                 lintTask.indentSize = kotlinterExtention.indentSize
+                lintTask.continuationIndentSize = kotlinterExtention.continuationIndentSize
                 lintTask.reports = kotlinterExtention.reporters().associate { reporter ->
                     reporter to project.reportFile("${lintTask.sourceSetId}-lint.${reporterFileExtension(reporter)}")
                 }
             }
             project.tasks.withType(FormatTask::class.java) { formatTask ->
                 formatTask.indentSize = kotlinterExtention.indentSize
+                formatTask.continuationIndentSize = kotlinterExtention.continuationIndentSize
             }
         }
     }

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/support/ktLintConfig.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/support/ktLintConfig.kt
@@ -1,3 +1,5 @@
 package org.jmailen.gradle.kotlinter.support
 
-fun userData(indentSize: Int) = mapOf("indent_size" to indentSize.toString())
+fun userData(indentSize: Int, continuationIndentSize: Int) = mapOf(
+        "indent_size" to indentSize.toString(),
+        "continuation_indent_size" to continuationIndentSize.toString())

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/FormatTask.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/FormatTask.kt
@@ -20,6 +20,9 @@ open class FormatTask : SourceTask() {
     @Input
     var indentSize = KotlinterExtension.DEFAULT_INDENT_SIZE
 
+    @Input
+    var continuationIndentSize = KotlinterExtension.DEFAULT_CONTINUATION_INDENT_SIZE
+
     @TaskAction
     fun run() {
         var fixes = ""
@@ -64,14 +67,26 @@ open class FormatTask : SourceTask() {
     }
 
     private fun formatKt(file: File, ruleSets: List<RuleSet>, onError: (line: Int, col: Int, detail: String, corrected: Boolean) -> Unit): String {
-        return KtLint.format(file.readText(), ruleSets, userData(indentSize = indentSize)) { error, corrected ->
-            onError(error.line, error.col, error.detail, corrected)
+        return KtLint.format(
+                file.readText(),
+                ruleSets,
+                userData(
+                        indentSize = indentSize,
+                        continuationIndentSize = continuationIndentSize
+                )) { error, corrected ->
+        onError(error.line, error.col, error.detail, corrected)
         }
     }
 
     private fun formatKts(file: File, ruleSets: List<RuleSet>, onError: (line: Int, col: Int, detail: String, corrected: Boolean) -> Unit): String {
-        return KtLint.formatScript(file.readText(), ruleSets, userData(indentSize = indentSize)) { error, corrected ->
-            onError(error.line, error.col, error.detail, corrected)
+        return KtLint.formatScript(
+                file.readText(),
+                ruleSets,
+                userData(
+                        indentSize = indentSize,
+                        continuationIndentSize = continuationIndentSize
+                )) { error, corrected ->
+        onError(error.line, error.col, error.detail, corrected)
         }
     }
 }

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/LintTask.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/LintTask.kt
@@ -7,7 +7,6 @@ import org.gradle.api.GradleException
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.OutputFiles
 import org.gradle.api.tasks.ParallelizableTask
 import org.gradle.api.tasks.SourceTask
@@ -29,6 +28,9 @@ open class LintTask : SourceTask() {
 
     @Input
     var indentSize = KotlinterExtension.DEFAULT_INDENT_SIZE
+
+    @Input
+    var continuationIndentSize = KotlinterExtension.DEFAULT_CONTINUATION_INDENT_SIZE
 
     @Internal
     var sourceSetId = ""
@@ -75,8 +77,21 @@ open class LintTask : SourceTask() {
     }
 
     private fun lintKt(file: File, ruleSets: List<RuleSet>, onError: (error: LintError) -> Unit) =
-            KtLint.lint(file.readText(), ruleSets, userData(indentSize = indentSize), onError)
+            KtLint.lint(
+                    file.readText(),
+                    ruleSets,
+                    userData(
+                            indentSize = indentSize,
+                            continuationIndentSize = continuationIndentSize),
+                    onError)
+
 
     private fun lintKts(file: File, ruleSets: List<RuleSet>, onError: (error: LintError) -> Unit) =
-            KtLint.lintScript(file.readText(), ruleSets, userData(indentSize = indentSize), onError)
+            KtLint.lintScript(
+                    file.readText(),
+                    ruleSets,
+                    userData(
+                            indentSize = indentSize,
+                            continuationIndentSize = continuationIndentSize),
+                    onError)
 }


### PR DESCRIPTION
Ktlin release [0.13.0](https://github.com/shyiko/ktlint/releases/tag/0.13.0)
This version support `continuation_indent_size` (see https://github.com/shyiko/ktlint/issues/76)

**Important** Unfortunately, I don't know how to properly test my changes (somehow use plugin from local build). Please verify if it actually works before merge or give me a hint how I can do it.

PS. Would be nice to have 
* simple project as separate module
* contributing guideline
* run ktlint on this project before merging PR (I've noticed unused import)