### PR TITLE
Support sourceSet customization and rev to 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Available on the Gradle Plugins Portal: https://plugins.gradle.org/plugin/org.jm
 
 ```groovy
 plugins {
-    id 'org.jmailen.kotlinter' version '1.12.0'
+    id 'org.jmailen.kotlinter' version '2.0.0'
 }
 ```
 
@@ -89,11 +89,13 @@ Reporters behave as described at: https://github.com/shyiko/ktlint
 ### Customizing Tasks
 
 The `formatKotlin`*`SourceSet`* and `lintKotlin`*`SourceSet`* tasks inherit from [SourceTask](https://docs.gradle.org/current/dsl/org.gradle.api.tasks.SourceTask.html)
-so you can customize includes, excludes, and source.
+so you can customize includes, excludes, and source. You must do this in `project.afterEvaluate` since tasks are dynamically created based on SourceSets.
 
 ```groovy
-lintKotlinMain {
-    exclude '**/*Generated.kt'
+afterEvaluate {
+    lintKotlinMain {
+        exclude '**/*Generated.kt'
+    }
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     testRuntime 'com.android.tools.build:gradle:3.0.1'
 }
 
-version = '1.12.0'
+version = '2.0.0'
 group = 'org.jmailen.gradle'
 def pluginId = 'org.jmailen.kotlinter'
 

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterPlugin.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterPlugin.kt
@@ -21,29 +21,29 @@ class KotlinterPlugin : Plugin<Project> {
             "kotlin-android" to this::androidSourceSets)
 
     override fun apply(project: Project) {
-        val kotlinterExtention = project.extensions.create("kotlinter", KotlinterExtension::class.java)
-
-        // for known kotlin plugins, create tasks by convention.
-        val kotlinApplier = KotlinterApplier(project)
-        extendablePlugins.forEach { pluginId, sourceResolver ->
-            project.plugins.withId(pluginId) {
-                val sourceSets = sourceResolver(project)
-                kotlinApplier.createTasks(sourceSets)
-            }
-        }
+        val kotlinterExtension = project.extensions.create("kotlinter", KotlinterExtension::class.java)
 
         project.afterEvaluate {
+            // for known kotlin plugins, create tasks by convention.
+            val kotlinApplier = KotlinterApplier(project)
+            extendablePlugins.forEach { pluginId, sourceResolver ->
+                project.plugins.withId(pluginId) {
+                    val sourceSets = sourceResolver(project)
+                    kotlinApplier.createTasks(sourceSets)
+                }
+            }
+
             kotlinApplier.lintTasks.forEach { lintTask ->
-                lintTask.ignoreFailures = kotlinterExtention.ignoreFailures
-                lintTask.indentSize = kotlinterExtention.indentSize
-                lintTask.continuationIndentSize = kotlinterExtention.continuationIndentSize
-                lintTask.reports = kotlinterExtention.reporters().associate { reporter ->
+                lintTask.ignoreFailures = kotlinterExtension.ignoreFailures
+                lintTask.indentSize = kotlinterExtension.indentSize
+                lintTask.continuationIndentSize = kotlinterExtension.continuationIndentSize
+                lintTask.reports = kotlinterExtension.reporters().associate { reporter ->
                     reporter to project.reportFile("${lintTask.sourceSetId}-lint.${reporterFileExtension(reporter)}")
                 }
             }
             kotlinApplier.formatTasks.forEach { formatTask ->
-                formatTask.indentSize = kotlinterExtention.indentSize
-                formatTask.continuationIndentSize = kotlinterExtention.continuationIndentSize
+                formatTask.indentSize = kotlinterExtension.indentSize
+                formatTask.continuationIndentSize = kotlinterExtension.continuationIndentSize
             }
         }
     }


### PR DESCRIPTION
Fixes #53 

Before the build lifecycle was implemented such that if sourceSets were customized,
kotlinter would have already created tasks based on the original sourceSets. If we
do this instead during `project.afterEvaluate` it can work off of the final definitions.

One consequence is that any customization of kotlinter created tasks must be wrapped in an
`afterEvaluate` block since they don't exist during the first build configuration pass. This
prompts a bump to 2.0 since it will be a breaking check for some builds.