### PR TITLE
Fix detection of customized SourceSets

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Available on the Gradle Plugins Portal: https://plugins.gradle.org/plugin/org.jm
 
 ```groovy
 plugins {
-    id 'org.jmailen.kotlinter' version '1.14.0'
+    id 'org.jmailen.kotlinter' version '1.15.0'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     testRuntime 'com.android.tools.build:gradle:3.0.1'
 }
 
-version = '1.14.0'
+version = '1.15.0'
 group = 'org.jmailen.gradle'
 def pluginId = 'org.jmailen.kotlinter'
 


### PR DESCRIPTION
Before the plugin only created tasks correctly for source sets built into the convention
of the plugin (JVM or Android). Now we use the SourceSetContainer's `all { action }` block to create tasks in
a deferred manner after all have been defined.

It turns out this can be done without changing the outward behavior of the plugin, types of
tasks, or compatibility with older builds. It did require some substantial internal refactoring,
mostly to allow for each plugin source set resolver to take an action to apply for each
source set discovered which contains Kotlin files.

Fixes #53