### PR TITLE
Safeguard plugin applying code to only support module types

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Available on the Gradle Plugins Portal: https://plugins.gradle.org/plugin/org.jm
 
 ```groovy
 plugins {
-    id 'org.jmailen.kotlinter' version '1.15.0'
+    id 'org.jmailen.kotlinter' version '1.15.1'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,31 @@ Gradle plugin for linting and formatting Kotlin source files using the awesome [
 
 Available on the Gradle Plugins Portal: https://plugins.gradle.org/plugin/org.jmailen.kotlinter
 
+#### Single module
 ```groovy
 plugins {
     id 'org.jmailen.kotlinter' version '1.15.1'
 }
+```
+
+#### Multi-module and Android
+
+Root `build.gradle`
+```groovy
+buildscript {
+    repositories {
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
+    }
+    dependencies {
+        classpath 'gradle.plugin.org.jmailen.gradle:kotlinter-gradle:1.15.1'
+    }
+}
+```
+Each module `build.gradle` with Kotlin source
+```groovy
+apply plugin: 'org.jmailen.kotlinter'
 ```
 
 ### Compatibility

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     testRuntime 'com.android.tools.build:gradle:3.0.1'
 }
 
-version = '1.15.0'
+version = '1.15.1'
 group = 'org.jmailen.gradle'
 def pluginId = 'org.jmailen.kotlinter'
 

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterPlugin.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterPlugin.kt
@@ -33,9 +33,10 @@ class KotlinterPlugin : Plugin<Project> {
                 sourceResolver.applyToAll(project) { id, files ->
                     taskCreator.createSourceSetTasks(id, files)
                 }
+
+                taskCreator.createParentTasks()
             }
         }
-        taskCreator.createParentTasks()
 
         project.afterEvaluate {
             taskCreator.lintTasks.forEach { lintTask ->


### PR DESCRIPTION
If you accidentally apply the kotlinter plugin to a gradle module which is not an android or kotlin-jvm module you'll get an error when it tries to create the parent tasks and make the non-existent `check` task depend on them.
See #65