### PR TITLE
Support relocatable build cache for lint, remove incremental support …

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Available on the Gradle Plugins Portal: https://plugins.gradle.org/plugin/org.jm
 #### Single module
 ```groovy
 plugins {
-    id 'org.jmailen.kotlinter' version '1.18.0'
+    id 'org.jmailen.kotlinter' version '1.19.0'
 }
 ```
 
@@ -26,7 +26,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'org.jmailen.gradle:kotlinter-gradle:1.18.0'
+        classpath 'org.jmailen.gradle:kotlinter-gradle:1.19.0'
     }
 }
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,9 @@
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '1.2.70'
+    id 'org.jetbrains.kotlin.jvm' version '1.2.71'
     id 'com.gradle.plugin-publish' version '0.10.0'
     id 'java-gradle-plugin'
     id 'maven-publish'
-    id 'org.jmailen.kotlinter' version '1.17.0'
+    id 'org.jmailen.kotlinter' version '1.18.0'
     id 'idea'
 }
 
@@ -22,7 +22,7 @@ dependencies {
     testRuntime 'com.android.tools.build:gradle:3.1.3'
 }
 
-version = '1.18.0'
+version = '1.19.0'
 group = 'org.jmailen.gradle'
 def pluginId = 'org.jmailen.kotlinter'
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,6 @@
 //include 'test-project'
 
 rootProject.name = 'kotlinter-gradle'
+
+enableFeaturePreview('STABLE_PUBLISHING')
+

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/FormatTask.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/FormatTask.kt
@@ -4,7 +4,6 @@ import com.github.shyiko.ktlint.core.KtLint
 import com.github.shyiko.ktlint.core.RuleSet
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.SourceTask
 import org.gradle.api.tasks.TaskAction
 import org.jmailen.gradle.kotlinter.KotlinterExtension
@@ -14,7 +13,6 @@ import java.io.File
 
 open class FormatTask : SourceTask() {
 
-    @OutputFile
     lateinit var report: File
 
     @Input

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/LintTask.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/LintTask.kt
@@ -9,6 +9,8 @@ import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputFiles
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.SourceTask
 import org.gradle.api.tasks.TaskAction
 import org.jmailen.gradle.kotlinter.KotlinterExtension
@@ -21,6 +23,7 @@ import java.io.File
 open class LintTask : SourceTask() {
 
     @OutputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
     lateinit var reports: Map<String, File>
 
     @Input


### PR DESCRIPTION
…from format

For format incremental build support is rarely useful and there's an edge case where it won't re-run if you revert changes to prior state.