### PR TITLE
Added two functional tests in preparation for Worker migration.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ out
 *.iml
 TODO.md
 .idea
+.gradle

--- a/build.gradle
+++ b/build.gradle
@@ -16,15 +16,17 @@ repositories {
 dependencies {
     implementation 'com.github.shyiko:ktlint:0.30.0'
     implementation 'me.cassiano:ktlint-html-reporter:0.2.0'
-    implementation 'org.jetbrains.kotlin:kotlin-gradle-plugin'
     
-    compileOnly 'com.android.tools.build:gradle:3.0.1' // TODO this is a different version than the testRuntime dependency
-    compileOnly('org.jetbrains.kotlin:kotlin-reflect') {
-        because 'AGP has a transitive dependency on this, and we want to pin to a particular version'
-    }
+    compileOnly 'org.jetbrains.kotlin:kotlin-gradle-plugin'
+    compileOnly 'com.android.tools.build:gradle:3.3.1'
 
     testImplementation 'junit:junit:4.12'
-    testRuntime 'com.android.tools.build:gradle:3.1.3'
+    testRuntime 'com.android.tools.build:gradle:3.3.1'
+}
+
+// Required to put the Kotlin plugin on the classpath for the functional test suite
+tasks.withType(PluginUnderTestMetadata).configureEach {
+    pluginClasspath.from(configurations.compileOnly)
 }
 
 version = '1.21.0'

--- a/build.gradle
+++ b/build.gradle
@@ -14,12 +14,16 @@ repositories {
 }
 
 dependencies {
-    compile 'com.github.shyiko:ktlint:0.30.0'
-    compile 'me.cassiano:ktlint-html-reporter:0.2.0'
-    compileOnly 'org.jetbrains.kotlin:kotlin-gradle-plugin'
-    compileOnly 'com.android.tools.build:gradle:3.0.1'
-    testCompile 'junit:junit:4.12'
-    testRuntime 'org.jetbrains.kotlin:kotlin-gradle-plugin'
+    implementation 'com.github.shyiko:ktlint:0.30.0'
+    implementation 'me.cassiano:ktlint-html-reporter:0.2.0'
+    implementation 'org.jetbrains.kotlin:kotlin-gradle-plugin'
+    
+    compileOnly 'com.android.tools.build:gradle:3.0.1' // TODO this is a different version than the testRuntime dependency
+    compileOnly('org.jetbrains.kotlin:kotlin-reflect') {
+        because 'AGP has a transitive dependency on this, and we want to pin to a particular version'
+    }
+
+    testImplementation 'junit:junit:4.12'
     testRuntime 'com.android.tools.build:gradle:3.1.3'
 }
 

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/FunctionalTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/FunctionalTest.kt
@@ -1,0 +1,99 @@
+package org.jmailen.gradle.kotlinter.functional
+
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome.FAILED
+import org.gradle.testkit.runner.TaskOutcome.SUCCESS
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class FunctionalTest {
+
+    @get:Rule
+    val testProjectDir = TemporaryFolder()
+
+    private lateinit var settingsFile: File
+    private lateinit var buildFile: File
+    private lateinit var sourceDir: File
+
+    @Before
+    fun setup() {
+        settingsFile = testProjectDir.newFile("settings.gradle")
+        buildFile = testProjectDir.newFile("build.gradle")
+        sourceDir = testProjectDir.newFolder("src", "main", "kotlin")
+    }
+
+    @Test
+    fun `lintKotlinMain fails when lint errors detected`() {
+        settingsFile()
+        buildFile()
+
+        val className = "KotlinClass"
+        kotlinSourceFile("$className.kt", """
+            class $className {
+                private fun(){
+                    println ("hi")
+                }
+            }
+        """.trimIndent()
+        )
+
+        val result: BuildResult = GradleRunner.create()
+                .withProjectDir(testProjectDir.root)
+                .withArguments("lintKotlinMain")
+                .withPluginClasspath()
+                .buildAndFail()
+
+        assertTrue(result.output.contains("Lint error >.*$className.kt.*Missing spacing before \"\\{\"".toRegex()))
+        assertTrue(result.output.contains("Lint error >.*$className.kt.*Unexpected spacing before \"\\(\"".toRegex()))
+        assertEquals(FAILED, result.task(":lintKotlinMain")?.outcome)
+    }
+
+    @Test
+    fun `lintKotlinMain succeeds when no lint errors detected`() {
+        settingsFile()
+        buildFile()
+        kotlinSourceFile("KotlinClass.kt", """
+            class KotlinClass {
+                private fun() {
+                    println("hi")
+                }
+            }
+        """.trimIndent()
+        )
+
+        val result: BuildResult = GradleRunner.create()
+                .withProjectDir(testProjectDir.root)
+                .withArguments("lintKotlinMain")
+                .withPluginClasspath()
+                .build()
+
+        assertEquals(SUCCESS, result.task(":lintKotlinMain")?.outcome)
+    }
+
+    private fun settingsFile() = settingsFile.apply {
+        writeText("rootProject.name = 'kotlinter'")
+    }
+
+    private fun buildFile() = buildFile.apply {
+        writeText("""
+            plugins {
+                id 'org.jetbrains.kotlin.jvm' version '1.3.20'
+                id 'org.jmailen.kotlinter'
+            }
+
+            repositories {
+                jcenter()
+            }
+        """.trimIndent())
+    }
+
+    private fun kotlinSourceFile(name: String, content: String) = File(sourceDir, name).apply {
+        writeText(content)
+    }
+}


### PR DESCRIPTION
In preparation for use of the Worker API, I wanted to ensure there was some test coverage of the features in question, first. These tests use Gradle TestKit. I had to make a few adjustments to `build.gradle`, the most significant of which was
```
implementation 'org.jetbrains.kotlin:kotlin-gradle-plugin'
```
Without that, the functional tests wouldn't compile, since some required classes were not on the test compile classpath. Something to do with how TestKit works.