### PR TITLE
Parallelized Linting using the Gradle Worker API

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ kotlinter {
     continuationIndentSize = 4
     reporter = arrayOf("checkstyle", "plain")
     experimentalRules = false
+    fileChunkSize = 30
 }
 ```
 
@@ -198,6 +199,7 @@ kotlinter {
     continuationIndentSize = 4
     reporters = ['checkstyle', 'plain']
     experimentalRules = false
+    fileChunkSize = 30
 }
 ```
 
@@ -212,6 +214,8 @@ Reporters behave as described at: https://github.com/shyiko/ktlint
 *Note: `reporter` with a single value is deprecated but supported for backwards compatibility.
 
 The `experimentalRules` property enables rules which are part of ktlint's experimental rule set.
+
+The `fileChunkSize` property configures the number of files that are processes in one Gradle Worker API call.
 
 ### Customizing Tasks
 

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ kotlinter {
     continuationIndentSize = 4
     reporter = arrayOf("checkstyle", "plain")
     experimentalRules = false
-    fileChunkSize = 30
+    fileBatchSize = 30
 }
 ```
 
@@ -199,7 +199,7 @@ kotlinter {
     continuationIndentSize = 4
     reporters = ['checkstyle', 'plain']
     experimentalRules = false
-    fileChunkSize = 30
+    fileBatchSize = 30
 }
 ```
 
@@ -215,7 +215,7 @@ Reporters behave as described at: https://github.com/shyiko/ktlint
 
 The `experimentalRules` property enables rules which are part of ktlint's experimental rule set.
 
-The `fileChunkSize` property configures the number of files that are processes in one Gradle Worker API call.
+The `fileBatchSize` property configures the number of files that are processes in one Gradle Worker API call.
 
 ### Customizing Tasks
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     compileOnly 'com.android.tools.build:gradle:3.3.1'
 
     testImplementation 'junit:junit:4.12'
+    testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.1.0'
     testRuntime 'com.android.tools.build:gradle:3.3.1'
 }
 

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterExtension.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterExtension.kt
@@ -9,6 +9,7 @@ open class KotlinterExtension {
         const val DEFAULT_CONTINUATION_INDENT_SIZE = 4
         val DEFAULT_REPORTER = ReporterType.checkstyle.name
         const val DEFAULT_EXPERIMENTAL_RULES = false
+        const val DEFAULT_FILE_CHUNK_SIZE = 30
     }
 
     /** Don't fail build on lint issues */
@@ -23,6 +24,9 @@ open class KotlinterExtension {
     var reporters = arrayOf(DEFAULT_REPORTER)
 
     var experimentalRules = DEFAULT_EXPERIMENTAL_RULES
+
+    /** The file list is split into chunks and processed together on a Worker API call */
+    var fileChunkSize = DEFAULT_FILE_CHUNK_SIZE
 
     // for backwards compatibility
     fun reporters() = reporter?.let { arrayOf(it) } ?: reporters

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterExtension.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterExtension.kt
@@ -9,7 +9,7 @@ open class KotlinterExtension {
         const val DEFAULT_CONTINUATION_INDENT_SIZE = 4
         val DEFAULT_REPORTER = ReporterType.checkstyle.name
         const val DEFAULT_EXPERIMENTAL_RULES = false
-        const val DEFAULT_FILE_CHUNK_SIZE = 30
+        const val DEFAULT_FILE_BATCH_SIZE = 30
     }
 
     /** Don't fail build on lint issues */
@@ -25,8 +25,8 @@ open class KotlinterExtension {
 
     var experimentalRules = DEFAULT_EXPERIMENTAL_RULES
 
-    /** The file list is split into chunks and processed together on a Worker API call */
-    var fileChunkSize = DEFAULT_FILE_CHUNK_SIZE
+    /** The file list is split into batches and processed together on a Worker API call */
+    var fileBatchSize = DEFAULT_FILE_BATCH_SIZE
 
     // for backwards compatibility
     fun reporters() = reporter?.let { arrayOf(it) } ?: reporters

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterPlugin.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterPlugin.kt
@@ -47,7 +47,7 @@ class KotlinterPlugin : Plugin<Project> {
                     reporter to project.reportFile("${lintTask.sourceSetId}-lint.${reporterFileExtension(reporter)}")
                 }
                 lintTask.experimentalRules = kotlinterExtension.experimentalRules
-                lintTask.fileChunkSize = kotlinterExtension.fileChunkSize
+                lintTask.fileBatchSize = kotlinterExtension.fileBatchSize
             }
             taskCreator.formatTasks.forEach { formatTask ->
                 formatTask.indentSize = kotlinterExtension.indentSize

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterPlugin.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterPlugin.kt
@@ -47,6 +47,7 @@ class KotlinterPlugin : Plugin<Project> {
                     reporter to project.reportFile("${lintTask.sourceSetId}-lint.${reporterFileExtension(reporter)}")
                 }
                 lintTask.experimentalRules = kotlinterExtension.experimentalRules
+                lintTask.fileChunkSize = kotlinterExtension.fileChunkSize
             }
             taskCreator.formatTasks.forEach { formatTask ->
                 formatTask.indentSize = kotlinterExtension.indentSize

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/support/ExecutionContext.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/support/ExecutionContext.kt
@@ -1,0 +1,12 @@
+package org.jmailen.gradle.kotlinter.support
+
+import com.github.shyiko.ktlint.core.Reporter
+import org.gradle.api.logging.Logger
+
+/**
+ * Context that is needed in a Worker Runnable but cannot be passed directly.
+ */
+data class ExecutionContext(
+    val reporters: List<Reporter>,
+    val logger: Logger
+)

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/support/ExecutionContextRepository.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/support/ExecutionContextRepository.kt
@@ -15,16 +15,16 @@ class ExecutionContextRepository {
 
     private val executionContextById: ConcurrentMap<UUID, ExecutionContext> = ConcurrentHashMap<UUID, ExecutionContext>()
 
-    fun registerExecutionContext(executionContext: ExecutionContext): UUID {
+    fun register(executionContext: ExecutionContext): UUID {
         val id = UUID.randomUUID()
         executionContextById[id] = executionContext
         return id
     }
 
-    fun retrieveExecutionContext(id: UUID): ExecutionContext =
+    fun get(id: UUID): ExecutionContext =
         executionContextById.getValue(id)
 
-    fun unregisterExecutionContext(id: UUID) {
+    fun unregister(id: UUID) {
         executionContextById.remove(id)
     }
 }

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/support/ExecutionContextRepository.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/support/ExecutionContextRepository.kt
@@ -1,0 +1,30 @@
+package org.jmailen.gradle.kotlinter.support
+
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentMap
+
+/**
+ * Global repository storing ExecutionContext that needs to be available in Worker Runnable.
+ */
+class ExecutionContextRepository {
+
+    companion object {
+        val instance = ExecutionContextRepository()
+    }
+
+    private val executionContextById: ConcurrentMap<UUID, ExecutionContext> = ConcurrentHashMap<UUID, ExecutionContext>()
+
+    fun registerExecutionContext(executionContext: ExecutionContext): UUID {
+        val id = UUID.randomUUID()
+        executionContextById[id] = executionContext
+        return id
+    }
+
+    fun retrieveExecutionContext(id: UUID): ExecutionContext =
+        executionContextById.getValue(id)
+
+    fun unregisterExecutionContext(id: UUID) {
+        executionContextById.remove(id)
+    }
+}

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/support/HasErrorReporter.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/support/HasErrorReporter.kt
@@ -1,0 +1,20 @@
+package org.jmailen.gradle.kotlinter.support
+
+import com.github.shyiko.ktlint.core.LintError
+import com.github.shyiko.ktlint.core.Reporter
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * A Reporter collecting whether or not an error has occurred.
+ */
+class HasErrorReporter : Reporter {
+
+    val hasError: Boolean
+        get() = hasErrorAtomic.get()
+
+    private val hasErrorAtomic = AtomicBoolean(false)
+
+    override fun onLintError(file: String, err: LintError, corrected: Boolean) {
+        hasErrorAtomic.set(true)
+    }
+}

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/support/SortedThreadSafeReporterWrapper.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/support/SortedThreadSafeReporterWrapper.kt
@@ -1,0 +1,58 @@
+package org.jmailen.gradle.kotlinter.support
+
+import com.github.shyiko.ktlint.core.LintError
+import com.github.shyiko.ktlint.core.Reporter
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentMap
+
+/**
+ * A wrapper for a Reporter that guarantees thread safety and consistent ordering of all the calls to the reporter.
+ * As a downside, the calls to the wrapped reporter are delayed until the end of the execution.
+ */
+class SortedThreadSafeReporterWrapper(
+    private val wrapped: Reporter
+) : Reporter {
+
+    private val callsToBefore: ConcurrentMap<String, Unit> = ConcurrentHashMap()
+    private val lintErrorReports: ConcurrentMap<String, LintErrorReport> = ConcurrentHashMap()
+    private val callsToAfter: ConcurrentMap<String, Unit> = ConcurrentHashMap()
+
+    override fun beforeAll() {
+        wrapped.beforeAll()
+    }
+
+    override fun before(file: String) {
+        callsToBefore[file] = Unit
+    }
+
+    override fun onLintError(file: String, err: LintError, corrected: Boolean) {
+        lintErrorReports[file] = LintErrorReport(err, corrected)
+    }
+
+    override fun after(file: String) {
+        callsToAfter[file] = Unit
+    }
+
+    override fun afterAll() {
+        (callsToBefore.keys + lintErrorReports.keys + callsToAfter.keys)
+            .sorted()
+            .forEach { fileName ->
+                if (callsToBefore.contains(fileName)) {
+                    wrapped.before(fileName)
+                }
+                lintErrorReports[fileName]?.let { lintErrorReport ->
+                    wrapped.onLintError(fileName, lintErrorReport.lintError, lintErrorReport.corrected)
+                }
+                if (callsToAfter.contains(fileName)) {
+                    wrapped.after(fileName)
+                }
+            }
+
+        wrapped.afterAll()
+    }
+
+    private data class LintErrorReport(
+        val lintError: LintError,
+        val corrected: Boolean
+    )
+}

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/support/reporters.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/support/reporters.kt
@@ -17,12 +17,14 @@ enum class ReporterType {
 
 fun reporterFor(reporterName: String, output: File): Reporter {
     val out = PrintStream(output)
-    return when (ReporterType.valueOf(reporterName)) {
-        ReporterType.checkstyle -> CheckStyleReporter(out)
-        ReporterType.html -> HtmlReporter(out)
-        ReporterType.json -> JsonReporter(out)
-        ReporterType.plain -> PlainReporter(out)
-    }
+    return SortedThreadSafeReporterWrapper(
+        when (ReporterType.valueOf(reporterName)) {
+            ReporterType.checkstyle -> CheckStyleReporter(out)
+            ReporterType.html -> HtmlReporter(out)
+            ReporterType.json -> JsonReporter(out)
+            ReporterType.plain -> PlainReporter(out)
+        }
+    )
 }
 
 fun reporterFileExtension(reporterName: String) = when (ReporterType.valueOf(reporterName)) {

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/LintTask.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/LintTask.kt
@@ -60,7 +60,7 @@ open class LintTask @Inject constructor(
             reporterFor(reporter, report)
         } + hasErrorReporter
         val reporterRepository = ExecutionContextRepository.instance
-        val executionContextRepositoryId = reporterRepository.registerExecutionContext(ExecutionContext(reporters, logger))
+        val executionContextRepositoryId = reporterRepository.register(ExecutionContext(reporters, logger))
 
         reporters.onEach { it.beforeAll() }
 
@@ -82,7 +82,7 @@ open class LintTask @Inject constructor(
                 workerExecutor.submit(LintWorkerRunnable::class.java, LintWorkerConfigurationAction(parameters))
             }
         workerExecutor.await()
-        reporterRepository.unregisterExecutionContext(executionContextRepositoryId)
+        reporterRepository.unregister(executionContextRepositoryId)
 
         reporters.onEach { it.afterAll() }
         if (hasErrorReporter.hasError && !ignoreFailures) {

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/LintTask.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/LintTask.kt
@@ -48,7 +48,7 @@ open class LintTask @Inject constructor(
     var experimentalRules = KotlinterExtension.DEFAULT_EXPERIMENTAL_RULES
 
     @Input
-    var fileChunkSize = KotlinterExtension.DEFAULT_FILE_CHUNK_SIZE
+    var fileBatchSize = KotlinterExtension.DEFAULT_FILE_BATCH_SIZE
 
     @Internal
     var sourceSetId = ""
@@ -66,7 +66,7 @@ open class LintTask @Inject constructor(
 
         getSource()
             .toList()
-            .chunked(fileChunkSize)
+            .chunked(fileBatchSize)
             .map { files ->
                 LintWorkerParameters(
                     files = files,

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/lint/LintWorkerConfigurationAction.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/lint/LintWorkerConfigurationAction.kt
@@ -1,0 +1,18 @@
+package org.jmailen.gradle.kotlinter.tasks.lint
+
+import org.gradle.api.Action
+import org.gradle.workers.IsolationMode
+import org.gradle.workers.WorkerConfiguration
+
+/**
+ * Configures the worker with IsolationMode.NONE and the LintWorkerParameters.
+ */
+class LintWorkerConfigurationAction(
+    private val lintWorkerParameters: LintWorkerParameters
+) : Action<WorkerConfiguration> {
+
+    override fun execute(workerConfiguration: WorkerConfiguration) {
+        workerConfiguration.isolationMode = IsolationMode.NONE
+        workerConfiguration.setParams(lintWorkerParameters)
+    }
+}

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/lint/LintWorkerParameters.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/lint/LintWorkerParameters.kt
@@ -1,0 +1,18 @@
+package org.jmailen.gradle.kotlinter.tasks.lint
+
+import java.io.File
+import java.io.Serializable
+import java.util.UUID
+
+/**
+ * Serializable stateless parameters that are needed by the LintWorkerRunnable.
+ */
+data class LintWorkerParameters(
+    val files: List<File>,
+    val projectDirectory: File,
+    val name: String,
+    val executionContextRepositoryId: UUID,
+    val experimentalRules: Boolean,
+    val indentSize: Int,
+    val continuationIndentSize: Int
+) : Serializable

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/lint/LintWorkerRunnable.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/lint/LintWorkerRunnable.kt
@@ -18,7 +18,7 @@ class LintWorkerRunnable @Inject constructor(
     parameters: LintWorkerParameters
 ) : Runnable {
 
-    private val executionContext = ExecutionContextRepository.instance.retrieveExecutionContext(parameters.executionContextRepositoryId)
+    private val executionContext = ExecutionContextRepository.instance.get(parameters.executionContextRepositoryId)
     private val reporters: List<Reporter> = executionContext.reporters
     private val logger: Logger = executionContext.logger
     private val files: List<File> = parameters.files

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/lint/LintWorkerRunnable.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/lint/LintWorkerRunnable.kt
@@ -1,0 +1,77 @@
+package org.jmailen.gradle.kotlinter.tasks.lint
+
+import com.github.shyiko.ktlint.core.KtLint
+import com.github.shyiko.ktlint.core.LintError
+import com.github.shyiko.ktlint.core.Reporter
+import com.github.shyiko.ktlint.core.RuleSet
+import org.gradle.api.logging.Logger
+import org.jmailen.gradle.kotlinter.support.ExecutionContextRepository
+import org.jmailen.gradle.kotlinter.support.resolveRuleSets
+import org.jmailen.gradle.kotlinter.support.userData
+import java.io.File
+import javax.inject.Inject
+
+/**
+ * Runnable used in the Gradle Worker API to run lint on a chunk of files.
+ */
+class LintWorkerRunnable @Inject constructor(
+    parameters: LintWorkerParameters
+) : Runnable {
+
+    private val executionContext = ExecutionContextRepository.instance.retrieveExecutionContext(parameters.executionContextRepositoryId)
+    private val reporters: List<Reporter> = executionContext.reporters
+    private val logger: Logger = executionContext.logger
+    private val files: List<File> = parameters.files
+    private val projectDirectory: File = parameters.projectDirectory
+    private val name: String = parameters.name
+    private val experimentalRules: Boolean = parameters.experimentalRules
+    private val indentSize: Int = parameters.indentSize
+    private val continuationIndentSize: Int = parameters.continuationIndentSize
+
+    override fun run() {
+        files
+            .forEach { file ->
+                val relativePath = file.toRelativeString(projectDirectory)
+                reporters.onEach { it.before(relativePath) }
+                logger.debug("$name linting: $relativePath")
+
+                val lintFunc = when (file.extension) {
+                    "kt" -> ::lintKt
+                    "kts" -> ::lintKts
+                    else -> {
+                        logger.debug("$name ignoring non Kotlin file: $relativePath")
+                        null
+                    }
+                }
+
+                lintFunc?.invoke(file, resolveRuleSets(experimentalRules)) { error ->
+                    reporters.onEach { it.onLintError(relativePath, error, false) }
+
+                    val errorStr = "$relativePath:${error.line}:${error.col}: ${error.detail}"
+                    logger.quiet("Lint error > $errorStr")
+                }
+
+                reporters.onEach { it.after(relativePath) }
+            }
+    }
+
+    private fun lintKt(file: File, ruleSets: List<RuleSet>, onError: (error: LintError) -> Unit) =
+        KtLint.lint(
+            file.readText(),
+            ruleSets,
+            userData(
+                indentSize = indentSize,
+                continuationIndentSize = continuationIndentSize,
+                filePath = file.path
+            ), onError)
+
+    private fun lintKts(file: File, ruleSets: List<RuleSet>, onError: (error: LintError) -> Unit) =
+        KtLint.lintScript(
+            file.readText(),
+            ruleSets,
+            userData(
+                indentSize = indentSize,
+                continuationIndentSize = continuationIndentSize,
+                filePath = file.path
+            ), onError)
+}

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/lint/LintWorkerRunnable.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/lint/LintWorkerRunnable.kt
@@ -12,7 +12,7 @@ import java.io.File
 import javax.inject.Inject
 
 /**
- * Runnable used in the Gradle Worker API to run lint on a chunk of files.
+ * Runnable used in the Gradle Worker API to run lint on a batch of files.
  */
 class LintWorkerRunnable @Inject constructor(
     parameters: LintWorkerParameters

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/support/ExecutionContextRepositoryTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/support/ExecutionContextRepositoryTest.kt
@@ -7,23 +7,23 @@ import org.junit.Test
 class ExecutionContextRepositoryTest {
 
     @Test
-    fun retrievingRegisteredContextWorks() {
+    fun getRegisteredContextWorks() {
         val repository = ExecutionContextRepository.instance
         val executionContext = ExecutionContext(emptyList(), mock())
-        val id = repository.registerExecutionContext(executionContext)
+        val id = repository.register(executionContext)
 
-        val result = repository.retrieveExecutionContext(id)
+        val result = repository.get(id)
 
         assertEquals(executionContext, result)
     }
 
     @Test(expected = NoSuchElementException::class)
-    fun retrievingUnregisteredContextFails() {
+    fun getUnregisteredContextFails() {
         val repository = ExecutionContextRepository.instance
         val executionContext = ExecutionContext(emptyList(), mock())
-        val id = repository.registerExecutionContext(executionContext)
-        repository.unregisterExecutionContext(id)
+        val id = repository.register(executionContext)
+        repository.unregister(id)
 
-        repository.retrieveExecutionContext(id)
+        repository.get(id)
     }
 }

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/support/ExecutionContextRepositoryTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/support/ExecutionContextRepositoryTest.kt
@@ -1,0 +1,29 @@
+package org.jmailen.gradle.kotlinter.support
+
+import com.nhaarman.mockitokotlin2.mock
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ExecutionContextRepositoryTest {
+
+    @Test
+    fun retrievingRegisteredContextWorks() {
+        val repository = ExecutionContextRepository.instance
+        val executionContext = ExecutionContext(emptyList(), mock())
+        val id = repository.registerExecutionContext(executionContext)
+
+        val result = repository.retrieveExecutionContext(id)
+
+        assertEquals(executionContext, result)
+    }
+
+    @Test(expected = NoSuchElementException::class)
+    fun retrievingUnregisteredContextFails() {
+        val repository = ExecutionContextRepository.instance
+        val executionContext = ExecutionContext(emptyList(), mock())
+        val id = repository.registerExecutionContext(executionContext)
+        repository.unregisterExecutionContext(id)
+
+        repository.retrieveExecutionContext(id)
+    }
+}

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/support/HasErrorReporterTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/support/HasErrorReporterTest.kt
@@ -1,0 +1,33 @@
+package org.jmailen.gradle.kotlinter.support
+
+import com.github.shyiko.ktlint.core.LintError
+import org.junit.Assert.assertTrue
+import org.junit.Assert.assertFalse
+import org.junit.Before
+import org.junit.Test
+
+class HasErrorReporterTest {
+
+    private lateinit var reporter: HasErrorReporter
+
+    @Before
+    fun setUp() {
+        reporter = HasErrorReporter()
+    }
+
+    @Test
+    fun hasErrorReturnsFalseForOnLintErrorNeverCalled() {
+        val result = reporter.hasError
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun hasErrorReturnsTrueForOnLintErrorCalled() {
+        reporter.onLintError("", LintError(0, 0, "", ""), false)
+
+        val result = reporter.hasError
+
+        assertTrue(result)
+    }
+}

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/support/SortedThreadSafeReporterWrapperTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/support/SortedThreadSafeReporterWrapperTest.kt
@@ -1,0 +1,121 @@
+package org.jmailen.gradle.kotlinter.support
+
+import com.github.shyiko.ktlint.core.LintError
+import com.github.shyiko.ktlint.core.Reporter
+import com.nhaarman.mockitokotlin2.inOrder
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.never
+import com.nhaarman.mockitokotlin2.verify
+
+import org.junit.Before
+import org.junit.Test
+
+class SortedThreadSafeReporterWrapperTest {
+
+    private lateinit var wrapped: Reporter
+
+    private lateinit var reporter: SortedThreadSafeReporterWrapper
+
+    @Before
+    fun setUp() {
+        wrapped = mock()
+
+        reporter = SortedThreadSafeReporterWrapper(wrapped)
+    }
+
+    @Test
+    fun beforeAllIsDelegatedToWrapper() {
+        reporter.beforeAll()
+
+        verify(wrapped).beforeAll()
+    }
+
+    @Test
+    fun beforeIsNotDirectlyDelegated() {
+        val fileName = "fileName"
+
+        reporter.before(fileName)
+
+        verify(wrapped, never()).before(fileName)
+    }
+
+    @Test
+    fun beforeIsDelegatedInAfterAll() {
+        val fileName = "fileName"
+        reporter.before(fileName)
+
+        reporter.afterAll()
+
+        verify(wrapped).before(fileName)
+    }
+
+    @Test
+    fun onLintErrorIsNotDirectlyDelegated() {
+        val fileName = "fileName"
+        val lintError = LintError(0, 0, "", "")
+        val corrected = false
+
+        reporter.onLintError(fileName, lintError, corrected)
+
+        verify(wrapped, never()).onLintError(fileName, lintError, corrected)
+    }
+
+    @Test
+    fun onLintErrorIsDelegatedInAfterAll() {
+        val fileName = "fileName"
+        val lintError = LintError(0, 0, "", "")
+        val corrected = false
+        reporter.onLintError(fileName, lintError, corrected)
+
+        reporter.afterAll()
+
+        verify(wrapped).onLintError(fileName, lintError, corrected)
+    }
+
+    @Test
+    fun afterIsNotDirectlyDelegated() {
+        val fileName = "fileName"
+
+        reporter.after(fileName)
+
+        verify(wrapped, never()).after(fileName)
+    }
+
+    @Test
+    fun afterIsDelegatedInAfterAll() {
+        val fileName = "fileName"
+        reporter.after(fileName)
+
+        reporter.afterAll()
+
+        verify(wrapped).after(fileName)
+    }
+
+    @Test
+    fun afterAllDelegatesInSortedOrder() {
+        val firstFileName = "b"
+        val firstLintError = LintError(0, 0, "", "")
+        val firstCorrected = true
+        val secondFileName = "a"
+        val secondLintError = LintError(1, 0, "", "")
+        val secondCorrected = false
+        reporter.before(firstFileName)
+        reporter.onLintError(firstFileName, firstLintError, firstCorrected)
+        reporter.after(firstFileName)
+        reporter.before(secondFileName)
+        reporter.onLintError(secondFileName, secondLintError, secondCorrected)
+        reporter.after(secondFileName)
+
+        reporter.afterAll()
+
+        val inOrder = inOrder(wrapped)
+        inOrder.verify(wrapped).before(secondFileName)
+        inOrder.verify(wrapped).onLintError(secondFileName, secondLintError, secondCorrected)
+        inOrder.verify(wrapped).after(secondFileName)
+        inOrder.verify(wrapped).before(firstFileName)
+        inOrder.verify(wrapped).onLintError(firstFileName, firstLintError, firstCorrected)
+        inOrder.verify(wrapped).after(firstFileName)
+        inOrder.verify(wrapped).afterAll()
+        inOrder.verifyNoMoreInteractions()
+    }
+}


### PR DESCRIPTION
Improved version of parallel execution of linting based on discussions in https://github.com/jeremymailen/kotlinter-gradle/pull/86 . Feedback is welcome!

Comments / Questions / Open Points
1. Experimentation (1) on my local project showed the sweet spot for file chunk size to be at approximately 30 files; therefore I chose that as the default.
2. I'm not entirely happy with the `ExecutionContextRepository`; if any of you guys see a different mechanism for reaching the same goal that with Gradle Worker API; please let me know.
3. `SortedThreadSafeReporterWrapper` waits delegating the calls to the wrapped Reporter until the end which is not ideal. Unfortunately, I don't see a way to ensure consistent ordering independent of Reporter implementation without waiting until the end. Ideas are welcome.
4. It would be nice to report the currently processed files onto the _gradle console_ the same way as the currently run tests are shown (multithreaded, changing output). Unfortunately, I couldn't figure out how to do that. In case any of you know how to do that, please let me know and I'll implement it.

As soon as this PR is getting merged, I'm happy to do the same for the FormatTask.

(1) Measurements
Existing Kotlinter: 10.957s
New Kotlinter:
  - Chunk size 1:  5.959
  - Chunk size 5:  1.654
  - Chunk size 10: 1.305
  - Chunk size 20: 1.296
  - Chunk size 30: 1.258
  - Chunk size 40: 1.283
  - Chunk size 50: 1.301
