### PR TITLE
Fix #91 by reporting all lint errors in each file

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Available on the Gradle Plugins Portal: https://plugins.gradle.org/plugin/org.jm
 
 ```kotlin
 plugins {
-    id("org.jmailen.kotlinter") version "1.23.0"
+    id("org.jmailen.kotlinter") version "1.23.1"
 }
 ```
 
@@ -26,7 +26,7 @@ plugins {
 
 ```groovy
 plugins {
-    id "org.jmailen.kotlinter" version "1.23.0"
+    id "org.jmailen.kotlinter" version "1.23.1"
 }
 ```
 
@@ -46,7 +46,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath("org.jmailen.gradle:kotlinter-gradle:1.23.0")
+        classpath("org.jmailen.gradle:kotlinter-gradle:1.23.1")
     }
 }
 ```
@@ -71,7 +71,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath "org.jmailen.gradle:kotlinter-gradle:1.23.0"
+        classpath "org.jmailen.gradle:kotlinter-gradle:1.23.1"
     }
 }
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ tasks.withType(PluginUnderTestMetadata).configureEach {
     pluginClasspath.from(configurations.compileOnly)
 }
 
-version = '1.23.0'
+version = '1.23.1'
 group = 'org.jmailen.gradle'
 def pluginId = 'org.jmailen.kotlinter'
 

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/support/SortedThreadSafeReporterWrapperTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/support/SortedThreadSafeReporterWrapperTest.kt
@@ -98,12 +98,16 @@ class SortedThreadSafeReporterWrapperTest {
         val firstCorrected = true
         val secondFileName = "a"
         val secondLintError = LintError(1, 0, "", "")
+        val secondLintError2 = LintError(3, 2, "", "")
+        val secondLintError3 = LintError(2, 6, "", "")
         val secondCorrected = false
         reporter.before(firstFileName)
         reporter.onLintError(firstFileName, firstLintError, firstCorrected)
         reporter.after(firstFileName)
         reporter.before(secondFileName)
         reporter.onLintError(secondFileName, secondLintError, secondCorrected)
+        reporter.onLintError(secondFileName, secondLintError2, secondCorrected)
+        reporter.onLintError(secondFileName, secondLintError3, secondCorrected)
         reporter.after(secondFileName)
 
         reporter.afterAll()
@@ -111,6 +115,8 @@ class SortedThreadSafeReporterWrapperTest {
         val inOrder = inOrder(wrapped)
         inOrder.verify(wrapped).before(secondFileName)
         inOrder.verify(wrapped).onLintError(secondFileName, secondLintError, secondCorrected)
+        inOrder.verify(wrapped).onLintError(secondFileName, secondLintError3, secondCorrected)
+        inOrder.verify(wrapped).onLintError(secondFileName, secondLintError2, secondCorrected)
         inOrder.verify(wrapped).after(secondFileName)
         inOrder.verify(wrapped).before(firstFileName)
         inOrder.verify(wrapped).onLintError(firstFileName, firstLintError, firstCorrected)


### PR DESCRIPTION
In the migration to workers, the reporter wrapper was only recording and reporting the last error for each file instead of accumulating a list of them.