### PR TITLE
Fix #99 by resolving RuleSets in the task rather than worker api runnable

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Available on the Gradle Plugins Portal: https://plugins.gradle.org/plugin/org.jm
 
 ```kotlin
 plugins {
-    id("org.jmailen.kotlinter") version "1.25.0"
+    id("org.jmailen.kotlinter") version "1.25.1"
 }
 ```
 
@@ -26,7 +26,7 @@ plugins {
 
 ```groovy
 plugins {
-    id "org.jmailen.kotlinter" version "1.25.0"
+    id "org.jmailen.kotlinter" version "1.25.1"
 }
 ```
 
@@ -46,7 +46,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath("org.jmailen.gradle:kotlinter-gradle:1.25.0")
+        classpath("org.jmailen.gradle:kotlinter-gradle:1.25.1")
     }
 }
 ```
@@ -71,7 +71,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath "org.jmailen.gradle:kotlinter-gradle:1.25.0"
+        classpath "org.jmailen.gradle:kotlinter-gradle:1.25.1"
     }
 }
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'com.gradle.plugin-publish' version '0.10.0'
     id 'java-gradle-plugin'
     id 'maven-publish'
-    id 'org.jmailen.kotlinter' version '1.24.1'
+    id 'org.jmailen.kotlinter' version '1.25.0'
     id 'idea'
 }
 
@@ -30,7 +30,7 @@ tasks.withType(PluginUnderTestMetadata).configureEach {
     pluginClasspath.from(configurations.compileOnly)
 }
 
-version = '1.25.0'
+version = '1.25.1'
 group = 'org.jmailen.gradle'
 def pluginId = 'org.jmailen.kotlinter'
 

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/support/ruleSets.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/support/ruleSets.kt
@@ -7,8 +7,8 @@ import java.util.ServiceLoader
 import kotlin.comparisons.compareBy
 
 fun resolveRuleSets(
-    includeExperimentalRules: Boolean = false,
-    providers: Iterable<RuleSetProvider> = ServiceLoader.load(RuleSetProvider::class.java)
+    providers: Iterable<RuleSetProvider>,
+    includeExperimentalRules: Boolean = false
 ): List<RuleSet> {
     return providers
         .filter { includeExperimentalRules || it !is ExperimentalRuleSetProvider }
@@ -20,3 +20,5 @@ fun resolveRuleSets(
             }
         })
 }
+
+fun defaultProviders() = ServiceLoader.load(RuleSetProvider::class.java)

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/FormatTask.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/FormatTask.kt
@@ -7,7 +7,7 @@ import org.gradle.api.tasks.TaskAction
 import org.gradle.workers.WorkerExecutor
 import org.jmailen.gradle.kotlinter.KotlinterExtension
 import org.jmailen.gradle.kotlinter.support.ExecutionContextRepository
-import org.jmailen.gradle.kotlinter.support.resolveRuleSets
+import org.jmailen.gradle.kotlinter.support.defaultProviders
 import org.jmailen.gradle.kotlinter.tasks.format.FormatExecutionContext
 import org.jmailen.gradle.kotlinter.tasks.format.FormatWorkerConfigurationAction
 import org.jmailen.gradle.kotlinter.tasks.format.FormatWorkerParameters
@@ -40,9 +40,8 @@ open class FormatTask @Inject constructor(
 
     @TaskAction
     fun run() {
-        val ruleSets = resolveRuleSets(experimentalRules)
         val executionContextRepository = ExecutionContextRepository.formatInstance
-        val executionContext = FormatExecutionContext(ruleSets, logger)
+        val executionContext = FormatExecutionContext(defaultProviders(), logger)
         val executionContextRepositoryId = executionContextRepository.register(executionContext)
 
         source

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/FormatTask.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/FormatTask.kt
@@ -7,6 +7,7 @@ import org.gradle.api.tasks.TaskAction
 import org.gradle.workers.WorkerExecutor
 import org.jmailen.gradle.kotlinter.KotlinterExtension
 import org.jmailen.gradle.kotlinter.support.ExecutionContextRepository
+import org.jmailen.gradle.kotlinter.support.resolveRuleSets
 import org.jmailen.gradle.kotlinter.tasks.format.FormatExecutionContext
 import org.jmailen.gradle.kotlinter.tasks.format.FormatWorkerConfigurationAction
 import org.jmailen.gradle.kotlinter.tasks.format.FormatWorkerParameters
@@ -39,8 +40,9 @@ open class FormatTask @Inject constructor(
 
     @TaskAction
     fun run() {
+        val ruleSets = resolveRuleSets(experimentalRules)
         val executionContextRepository = ExecutionContextRepository.formatInstance
-        val executionContext = FormatExecutionContext(logger)
+        val executionContext = FormatExecutionContext(ruleSets, logger)
         val executionContextRepositoryId = executionContextRepository.register(executionContext)
 
         source

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/LintTask.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/LintTask.kt
@@ -14,8 +14,8 @@ import org.gradle.workers.WorkerExecutor
 import org.jmailen.gradle.kotlinter.KotlinterExtension
 import org.jmailen.gradle.kotlinter.support.HasErrorReporter
 import org.jmailen.gradle.kotlinter.support.ExecutionContextRepository
+import org.jmailen.gradle.kotlinter.support.defaultProviders
 import org.jmailen.gradle.kotlinter.support.reporterFor
-import org.jmailen.gradle.kotlinter.support.resolveRuleSets
 import org.jmailen.gradle.kotlinter.tasks.lint.LintExecutionContext
 import org.jmailen.gradle.kotlinter.tasks.lint.LintWorkerConfigurationAction
 import org.jmailen.gradle.kotlinter.tasks.lint.LintWorkerParameters
@@ -56,13 +56,12 @@ open class LintTask @Inject constructor(
 
     @TaskAction
     fun run() {
-        val ruleSets = resolveRuleSets(experimentalRules)
         val hasErrorReporter = HasErrorReporter()
         val reporters = reports.map { (reporter, report) ->
             reporterFor(reporter, report)
         } + hasErrorReporter
         val executionContextRepository = ExecutionContextRepository.lintInstance
-        val executionContextRepositoryId = executionContextRepository.register(LintExecutionContext(ruleSets, reporters, logger))
+        val executionContextRepositoryId = executionContextRepository.register(LintExecutionContext(defaultProviders(), reporters, logger))
 
         reporters.onEach { it.beforeAll() }
 

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/LintTask.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/LintTask.kt
@@ -15,6 +15,7 @@ import org.jmailen.gradle.kotlinter.KotlinterExtension
 import org.jmailen.gradle.kotlinter.support.HasErrorReporter
 import org.jmailen.gradle.kotlinter.support.ExecutionContextRepository
 import org.jmailen.gradle.kotlinter.support.reporterFor
+import org.jmailen.gradle.kotlinter.support.resolveRuleSets
 import org.jmailen.gradle.kotlinter.tasks.lint.LintExecutionContext
 import org.jmailen.gradle.kotlinter.tasks.lint.LintWorkerConfigurationAction
 import org.jmailen.gradle.kotlinter.tasks.lint.LintWorkerParameters
@@ -55,12 +56,13 @@ open class LintTask @Inject constructor(
 
     @TaskAction
     fun run() {
+        val ruleSets = resolveRuleSets(experimentalRules)
         val hasErrorReporter = HasErrorReporter()
         val reporters = reports.map { (reporter, report) ->
             reporterFor(reporter, report)
         } + hasErrorReporter
         val executionContextRepository = ExecutionContextRepository.lintInstance
-        val executionContextRepositoryId = executionContextRepository.register(LintExecutionContext(reporters, logger))
+        val executionContextRepositoryId = executionContextRepository.register(LintExecutionContext(ruleSets, reporters, logger))
 
         reporters.onEach { it.beforeAll() }
 

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/format/FormatExecutionContext.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/format/FormatExecutionContext.kt
@@ -1,6 +1,6 @@
 package org.jmailen.gradle.kotlinter.tasks.format
 
-import com.pinterest.ktlint.core.RuleSet
+import com.pinterest.ktlint.core.RuleSetProvider
 import org.gradle.api.logging.Logger
 import org.jmailen.gradle.kotlinter.support.ExecutionContext
 import java.util.Queue
@@ -10,7 +10,7 @@ import java.util.concurrent.ConcurrentLinkedQueue
  * Execution context for the formatting task.
  */
 data class FormatExecutionContext(
-    val ruleSets: List<RuleSet>,
+    val ruleSetProviders: Iterable<RuleSetProvider>,
     override val logger: Logger,
     val fixes: Queue<String> = ConcurrentLinkedQueue<String>()
 ) : ExecutionContext

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/format/FormatExecutionContext.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/format/FormatExecutionContext.kt
@@ -1,5 +1,6 @@
 package org.jmailen.gradle.kotlinter.tasks.format
 
+import com.pinterest.ktlint.core.RuleSet
 import org.gradle.api.logging.Logger
 import org.jmailen.gradle.kotlinter.support.ExecutionContext
 import java.util.Queue
@@ -9,6 +10,7 @@ import java.util.concurrent.ConcurrentLinkedQueue
  * Execution context for the formatting task.
  */
 data class FormatExecutionContext(
+    val ruleSets: List<RuleSet>,
     override val logger: Logger,
     val fixes: Queue<String> = ConcurrentLinkedQueue<String>()
 ) : ExecutionContext

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/format/FormatWorkerRunnable.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/format/FormatWorkerRunnable.kt
@@ -5,6 +5,7 @@ import com.pinterest.ktlint.core.RuleSet
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.logging.Logger
 import org.jmailen.gradle.kotlinter.support.ExecutionContextRepository
+import org.jmailen.gradle.kotlinter.support.resolveRuleSets
 import org.jmailen.gradle.kotlinter.support.userData
 import java.io.File
 import javax.inject.Inject
@@ -40,7 +41,8 @@ class FormatWorkerRunnable @Inject constructor(
                         null
                     }
                 }?.let { formatFunc ->
-                    val formattedText = formatFunc.invoke(file, executionContext.ruleSets) { line, col, detail, corrected ->
+                    val ruleSets = resolveRuleSets(executionContext.ruleSetProviders, experimentalRules)
+                    val formattedText = formatFunc.invoke(file, ruleSets) { line, col, detail, corrected ->
                         val errorStr = "$relativePath:$line:$col: $detail"
                         val msg = when (corrected) {
                             true -> "Format fixed > $errorStr"

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/format/FormatWorkerRunnable.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/format/FormatWorkerRunnable.kt
@@ -5,7 +5,6 @@ import com.pinterest.ktlint.core.RuleSet
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.logging.Logger
 import org.jmailen.gradle.kotlinter.support.ExecutionContextRepository
-import org.jmailen.gradle.kotlinter.support.resolveRuleSets
 import org.jmailen.gradle.kotlinter.support.userData
 import java.io.File
 import javax.inject.Inject
@@ -41,7 +40,7 @@ class FormatWorkerRunnable @Inject constructor(
                         null
                     }
                 }?.let { formatFunc ->
-                    val formattedText = formatFunc.invoke(file, resolveRuleSets(experimentalRules)) { line, col, detail, corrected ->
+                    val formattedText = formatFunc.invoke(file, executionContext.ruleSets) { line, col, detail, corrected ->
                         val errorStr = "$relativePath:$line:$col: $detail"
                         val msg = when (corrected) {
                             true -> "Format fixed > $errorStr"

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/lint/LintExecutionContext.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/lint/LintExecutionContext.kt
@@ -1,7 +1,7 @@
 package org.jmailen.gradle.kotlinter.tasks.lint
 
 import com.pinterest.ktlint.core.Reporter
-import com.pinterest.ktlint.core.RuleSet
+import com.pinterest.ktlint.core.RuleSetProvider
 import org.gradle.api.logging.Logger
 import org.jmailen.gradle.kotlinter.support.ExecutionContext
 
@@ -9,7 +9,7 @@ import org.jmailen.gradle.kotlinter.support.ExecutionContext
  * Execution context for the linting task.
  */
 data class LintExecutionContext(
-    val ruleSets: List<RuleSet>,
+    val ruleSetProviders: Iterable<RuleSetProvider>,
     val reporters: List<Reporter>,
     override val logger: Logger
 ) : ExecutionContext

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/lint/LintExecutionContext.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/lint/LintExecutionContext.kt
@@ -1,6 +1,7 @@
 package org.jmailen.gradle.kotlinter.tasks.lint
 
 import com.pinterest.ktlint.core.Reporter
+import com.pinterest.ktlint.core.RuleSet
 import org.gradle.api.logging.Logger
 import org.jmailen.gradle.kotlinter.support.ExecutionContext
 
@@ -8,6 +9,7 @@ import org.jmailen.gradle.kotlinter.support.ExecutionContext
  * Execution context for the linting task.
  */
 data class LintExecutionContext(
+    val ruleSets: List<RuleSet>,
     val reporters: List<Reporter>,
     override val logger: Logger
 ) : ExecutionContext

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/lint/LintWorkerRunnable.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/lint/LintWorkerRunnable.kt
@@ -6,6 +6,7 @@ import com.pinterest.ktlint.core.Reporter
 import com.pinterest.ktlint.core.RuleSet
 import org.gradle.api.logging.Logger
 import org.jmailen.gradle.kotlinter.support.ExecutionContextRepository
+import org.jmailen.gradle.kotlinter.support.resolveRuleSets
 import org.jmailen.gradle.kotlinter.support.userData
 import java.io.File
 import javax.inject.Inject
@@ -43,7 +44,8 @@ class LintWorkerRunnable @Inject constructor(
                     }
                 }
 
-                lintFunc?.invoke(file, executionContext.ruleSets) { error ->
+                val ruleSets = resolveRuleSets(executionContext.ruleSetProviders, experimentalRules)
+                lintFunc?.invoke(file, ruleSets) { error ->
                     reporters.onEach { it.onLintError(relativePath, error, false) }
 
                     val errorStr = "$relativePath:${error.line}:${error.col}: ${error.detail}"

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/lint/LintWorkerRunnable.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/lint/LintWorkerRunnable.kt
@@ -6,7 +6,6 @@ import com.pinterest.ktlint.core.Reporter
 import com.pinterest.ktlint.core.RuleSet
 import org.gradle.api.logging.Logger
 import org.jmailen.gradle.kotlinter.support.ExecutionContextRepository
-import org.jmailen.gradle.kotlinter.support.resolveRuleSets
 import org.jmailen.gradle.kotlinter.support.userData
 import java.io.File
 import javax.inject.Inject
@@ -44,7 +43,7 @@ class LintWorkerRunnable @Inject constructor(
                     }
                 }
 
-                lintFunc?.invoke(file, resolveRuleSets(experimentalRules)) { error ->
+                lintFunc?.invoke(file, executionContext.ruleSets) { error ->
                     reporters.onEach { it.onLintError(relativePath, error, false) }
 
                     val errorStr = "$relativePath:${error.line}:${error.col}: ${error.detail}"

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/support/ExecutionContextRepositoryTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/support/ExecutionContextRepositoryTest.kt
@@ -10,7 +10,7 @@ class ExecutionContextRepositoryTest {
     @Test
     fun getRegisteredContextWorks() {
         val repository = ExecutionContextRepository.lintInstance
-        val executionContext = LintExecutionContext(emptyList(), mock())
+        val executionContext = LintExecutionContext(mock(), emptyList(), mock())
         val id = repository.register(executionContext)
 
         val result = repository.get(id)
@@ -21,7 +21,7 @@ class ExecutionContextRepositoryTest {
     @Test(expected = NoSuchElementException::class)
     fun getUnregisteredContextFails() {
         val repository = ExecutionContextRepository.lintInstance
-        val executionContext = LintExecutionContext(emptyList(), mock())
+        val executionContext = LintExecutionContext(mock(), emptyList(), mock())
         val id = repository.register(executionContext)
         repository.unregister(id)
 

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/support/RuleSetsTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/support/RuleSetsTest.kt
@@ -13,14 +13,14 @@ class RuleSetsTest {
 
     @Test
     fun `resolveRuleSets loads from classpath providers`() {
-        val result = resolveRuleSets()
+        val result = resolveRuleSets(defaultProviders())
 
         assertEquals(listOf("standard"), result.map { it.id })
     }
 
     @Test
     fun `resolveRuleSets loads from classpath providers including experimental rules`() {
-        val result = resolveRuleSets(includeExperimentalRules = true)
+        val result = resolveRuleSets(defaultProviders(), true)
 
         assertEquals(listOf("standard", "experimental"), result.map { it.id })
     }
@@ -40,7 +40,7 @@ class RuleSetsTest {
 
     @Test
     fun `test compatibility`() {
-        KtLint.lint("""fun someFunc() = """"", resolveRuleSets(), {})
+        KtLint.lint("""fun someFunc() = """"", resolveRuleSets(defaultProviders())) {}
     }
 }
 


### PR DESCRIPTION
Using `ServiceLoader` in the runnable used by the worker api appears to cause a classloader scope issue.