### PR TITLE
Upgrade kotlin and android libraries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk11

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,9 @@
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '1.3.31'
+    id 'org.jetbrains.kotlin.jvm' version '1.3.41'
     id 'com.gradle.plugin-publish' version '0.10.0'
     id 'java-gradle-plugin'
     id 'maven-publish'
-    id 'org.jmailen.kotlinter' version '1.25.2'
+    id 'org.jmailen.kotlinter' version '1.26.0'
     id 'idea'
 }
 
@@ -18,11 +18,11 @@ dependencies {
     implementation 'me.cassiano:ktlint-html-reporter:0.2.1'
     
     compileOnly 'org.jetbrains.kotlin:kotlin-gradle-plugin'
-    compileOnly 'com.android.tools.build:gradle:3.3.1'
+    compileOnly 'com.android.tools.build:gradle:3.4.2'
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.1.0'
-    testRuntime 'com.android.tools.build:gradle:3.3.1'
+    testRuntime 'com.android.tools.build:gradle:3.4.2'
 }
 
 // Required to put the Kotlin plugin on the classpath for the functional test suite
@@ -66,5 +66,5 @@ publishing {
 }
 
 wrapper {
-    gradleVersion = '5.4.1'
+    gradleVersion = '5.5.1'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -5,7 +5,7 @@
 @rem you may not use this file except in compliance with the License.
 @rem You may obtain a copy of the License at
 @rem
-@rem      http://www.apache.org/licenses/LICENSE-2.0
+@rem      https://www.apache.org/licenses/LICENSE-2.0
 @rem
 @rem Unless required by applicable law or agreed to in writing, software
 @rem distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
- kotlin 1.3.41
- android gradle 3.4.2

Tested with JDK and Andoid projects in ranges kotlin 1.3.21 - 1.3.41 and Android back to 3.1.0.