### PR TITLE
Fix support for .editorconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Available on the Gradle Plugins Portal: https://plugins.gradle.org/plugin/org.jm
 
 ```kotlin
 plugins {
-    id("org.jmailen.kotlinter") version "2.1.0"
+    id("org.jmailen.kotlinter") version "2.1.1"
 }
 ```
 
@@ -26,7 +26,7 @@ plugins {
 
 ```groovy
 plugins {
-    id "org.jmailen.kotlinter" version "2.1.0"
+    id "org.jmailen.kotlinter" version "2.1.1"
 }
 ```
 
@@ -46,7 +46,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath("org.jmailen.gradle:kotlinter-gradle:2.1.0")
+        classpath("org.jmailen.gradle:kotlinter-gradle:2.1.1")
     }
 }
 ```
@@ -71,7 +71,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath "org.jmailen.gradle:kotlinter-gradle:2.1.0"
+        classpath "org.jmailen.gradle:kotlinter-gradle:2.1.1"
     }
 }
 ```
@@ -177,7 +177,7 @@ The `fileBatchSize` property configures the number of files that are processed i
 
 Kotlinter will configure itself using an `.editorconfig` file if one is present in your root project directory.
 
-For configuration values supported in both the `kotlinter` extension and `.editorconfig`, the `.editorconfig` values will take precedence.
+If a non-empty `disabledRules` value is specified in the `kotlinter` extension, it will take precedence over any `disabled_rules` in `.editorconfig`.
 
 See [Ktlint editorconfig](https://github.com/pinterest/ktlint#editorconfig) for supported values.
 

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ tasks.withType(PluginUnderTestMetadata).configureEach {
     pluginClasspath.from(configurations.compileOnly)
 }
 
-version = '2.1.0'
+version = '2.1.1'
 group = 'org.jmailen.gradle'
 def pluginId = 'org.jmailen.kotlinter'
 

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/support/KtLintUserData.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/support/KtLintUserData.kt
@@ -1,7 +1,14 @@
 package org.jmailen.gradle.kotlinter.support
 
-fun userData(ktLintParams: KtLintParams) = mapOf(
-    "indent_size" to ktLintParams.indentSize.toString(),
-    "continuation_indent_size" to ktLintParams.continuationIndentSize.toString(),
-    "disabled_rules" to ktLintParams.disabledRules.joinToString(",")
-)
+import org.jetbrains.kotlin.utils.addToStdlib.ifNotEmpty
+
+fun userData(ktLintParams: KtLintParams): Map<String, String> {
+    val userData = mutableMapOf(
+        "indent_size" to ktLintParams.indentSize.toString(),
+        "continuation_indent_size" to ktLintParams.continuationIndentSize.toString()
+    )
+    ktLintParams.disabledRules.ifNotEmpty {
+        userData["disabled_rules"] = joinToString(",")
+    }
+    return userData
+}


### PR DESCRIPTION
Also update the README to reflect that `kotlinter` extension will take precedence over editorconfig when values are specified.

**Why**
Now that `userData` passed into ktlint core takes precedence over values in the `.editorconfig` we need to be use to set a user data key on empty `disabledRules` in the `kotlinter` extension.

Fixes #112 