### PR TITLE
Remove deprecated annotation for output directory

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,13 +10,13 @@ plugins {
 repositories {
     mavenLocal()
     jcenter()
-    maven { url 'https://maven.google.com' }
+    google()
 }
 
 dependencies {
     implementation 'com.pinterest:ktlint:0.35.0'
     implementation 'me.cassiano:ktlint-html-reporter:0.2.1'
-    
+
     compileOnly 'org.jetbrains.kotlin:kotlin-gradle-plugin'
     compileOnly 'com.android.tools.build:gradle:3.4.2'
 

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/LintTask.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/LintTask.kt
@@ -30,7 +30,6 @@ open class LintTask @Inject constructor(
 ) : SourceTask() {
 
     @OutputFiles
-    @PathSensitive(PathSensitivity.RELATIVE)
     lateinit var reports: Map<String, File>
 
     @InputFiles


### PR DESCRIPTION
This removes the deprecated @PathSensitive annotation that is not allowed for @OutputFiles properties.

Addresses issue #120.