### PR TITLE
Fix #115 by lazy task sources evaluation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+[*.{kt,kts}]
+max_line_length = 140
+indent_size = 4
+continuation_indent_size = 4
+insert_final_newline = true

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '1.3.60'
+    id 'org.jetbrains.kotlin.jvm' version '1.3.61'
     id 'com.gradle.plugin-publish' version '0.10.1'
     id 'java-gradle-plugin'
     id 'maven-publish'
@@ -8,7 +8,6 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
     jcenter()
     google()
 }
@@ -25,11 +24,12 @@ dependencies {
     implementation "com.pinterest.ktlint:ktlint-ruleset-standard:$ktlintVers"
 
     compileOnly 'org.jetbrains.kotlin:kotlin-gradle-plugin'
-    compileOnly 'com.android.tools.build:gradle:3.4.2'
+    compileOnly 'com.android.tools.build:gradle:3.5.3'
 
-    testImplementation 'junit:junit:4.12'
-    testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.1.0'
-    testRuntime 'com.android.tools.build:gradle:3.4.2'
+    testImplementation 'junit:junit:4.13'
+    testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0'
+    testImplementation 'org.jetbrains:annotations:18.0.0'
+    testRuntime 'com.android.tools.build:gradle:3.5.3'
 }
 
 // Required to put the Kotlin plugin on the classpath for the functional test suite
@@ -62,6 +62,10 @@ pluginBundle {
             description = 'Lint and formatting for Kotlin using ktlint with configuration-free setup on JVM and Android projects'
         }
     }
+}
+
+java {
+    withSourcesJar()
 }
 
 publishing {

--- a/build.gradle
+++ b/build.gradle
@@ -29,8 +29,6 @@ dependencies {
     testImplementation 'junit:junit:4.13'
     testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0'
     testImplementation 'org.jetbrains:annotations:18.0.0'
-    testRuntime 'com.android.tools.build:gradle:3.5.3'
-    testRuntime 'org.jetbrains.kotlin:kotlin-gradle-plugin'
 }
 
 // Required to put the Kotlin plugin on the classpath for the functional test suite

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0'
     testImplementation 'org.jetbrains:annotations:18.0.0'
     testRuntime 'com.android.tools.build:gradle:3.5.3'
+    testRuntime 'org.jetbrains.kotlin:kotlin-gradle-plugin'
 }
 
 // Required to put the Kotlin plugin on the classpath for the functional test suite

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '1.3.61'
+    id 'org.jetbrains.kotlin.jvm' version '1.3.60'
     id 'com.gradle.plugin-publish' version '0.10.1'
     id 'java-gradle-plugin'
     id 'maven-publish'
@@ -31,7 +31,7 @@ dependencies {
     testImplementation 'org.jetbrains:annotations:18.0.0'
 }
 
-// Required to put the Kotlin plugin on the classpath for the functional test suite
+// Required to put all `compileOnly` dependencies on the classpath for the functional test suite
 tasks.withType(PluginUnderTestMetadata).configureEach {
     pluginClasspath.from(configurations.compileOnly)
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+kotlin.code.style=official

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterPlugin.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterPlugin.kt
@@ -42,7 +42,7 @@ class KotlinterPlugin : Plugin<Project> {
                         lintTask.reports = kotlinterExtension.reporters.associate { reporter ->
                             reporter to reportFile("$id-lint.${reporterFileExtension(reporter)}")
                         }
-                        lintTask.ktLintParams = kotlinterExtension.ktlintParams(editorConfigPath())
+                        lintTask.ktLintParams = kotlinterExtension.toKtLintParams(editorConfigPath())
                         lintTask.fileBatchSize = kotlinterExtension.fileBatchSize
                     }
                     lintKotlin.dependsOn(lintKotlinPerVariant)
@@ -50,7 +50,7 @@ class KotlinterPlugin : Plugin<Project> {
                     val formatKotlinPerVariant = tasks.register("formatKotlin${id.capitalize()}", FormatTask::class.java) { formatTask ->
                         formatTask.source(resolveSources)
                         formatTask.report = reportFile("$id-format.txt")
-                        formatTask.ktLintParams = kotlinterExtension.ktlintParams(editorConfigPath())
+                        formatTask.ktLintParams = kotlinterExtension.toKtLintParams(editorConfigPath())
                         formatTask.fileBatchSize = kotlinterExtension.fileBatchSize
                     }
                     formatKotlin.dependsOn(formatKotlinPerVariant)
@@ -119,7 +119,7 @@ internal object AndroidSourceSetResolver : SourceSetResolver {
     }
 }
 
-private fun KotlinterExtension.ktlintParams(editorConfigPath: String?) = KtLintParams(
+private fun KotlinterExtension.toKtLintParams(editorConfigPath: String?) = KtLintParams(
     indentSize,
     continuationIndentSize,
     experimentalRules,

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterPlugin.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterPlugin.kt
@@ -28,7 +28,7 @@ class KotlinterPlugin : Plugin<Project> {
     override fun apply(project: Project) = with(project) {
         val kotlinterExtension = extensions.create("kotlinter", KotlinterExtension::class.java)
 
-        // for known kotlin plugins, create tasks by convention.
+        // for known kotlin plugins, register tasks by convention.
         extendablePlugins.forEach { (pluginId, sourceResolver) ->
             plugins.withId(pluginId) {
 

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterPlugin.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterPlugin.kt
@@ -35,7 +35,7 @@ class KotlinterPlugin : Plugin<Project> {
                 val formatKotlin = registerParentFormatTask()
 
                 sourceResolver.applyToAll(project) { id, resolveSources ->
-                    val lintKotlinPerVariant = tasks.register("lintKotlin${id.capitalize()}", LintTask::class.java) { lintTask ->
+                    val lintTaskPerSourceSet = tasks.register("lintKotlin${id.capitalize()}", LintTask::class.java) { lintTask ->
                         lintTask.source(resolveSources)
                         lintTask.ignoreFailures = kotlinterExtension.ignoreFailures
                         lintTask.reports = kotlinterExtension.reporters.associate { reporter ->
@@ -45,7 +45,7 @@ class KotlinterPlugin : Plugin<Project> {
                         lintTask.fileBatchSize = kotlinterExtension.fileBatchSize
                     }
                     lintKotlin.configure { lintTask ->
-                        lintTask.dependsOn(lintKotlinPerVariant)
+                        lintTask.dependsOn(lintTaskPerSourceSet)
                     }
 
                     val formatKotlinPerVariant = tasks.register("formatKotlin${id.capitalize()}", FormatTask::class.java) { formatTask ->

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterPlugin.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterPlugin.kt
@@ -2,13 +2,14 @@ package org.jmailen.gradle.kotlinter
 
 import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.api.AndroidSourceSet
-import java.io.File
+import com.android.build.gradle.internal.tasks.factory.dependsOn
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.file.FileTree
 import org.gradle.api.file.SourceDirectorySet
 import org.gradle.api.internal.HasConvention
 import org.gradle.api.plugins.JavaPluginConvention
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.SourceSetContainer
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
@@ -20,109 +21,85 @@ import org.jmailen.gradle.kotlinter.tasks.LintTask
 class KotlinterPlugin : Plugin<Project> {
 
     val extendablePlugins = mapOf(
-            "org.jetbrains.kotlin.jvm" to KotlinJvmSourceSetResolver,
-            "kotlin-android" to AndroidSourceSetResolver)
+        "org.jetbrains.kotlin.jvm" to KotlinJvmSourceSetResolver,
+        "kotlin-android" to AndroidSourceSetResolver
+    )
 
-    override fun apply(project: Project) {
-        val kotlinterExtension = project.extensions.create("kotlinter", KotlinterExtension::class.java)
+    override fun apply(project: Project) = with(project) {
+        val kotlinterExtension = extensions.create("kotlinter", KotlinterExtension::class.java)
 
         // for known kotlin plugins, create tasks by convention.
-        val taskCreator = TaskCreator(project)
-        extendablePlugins.forEach { pluginId, sourceResolver ->
-            project.plugins.withId(pluginId) {
+        extendablePlugins.forEach { (pluginId, sourceResolver) ->
+            plugins.withId(pluginId) {
 
-                sourceResolver.applyToAll(project) { id, files ->
-                    taskCreator.createSourceSetTasks(id, files)
+                val lintKotlin = registerParentLintTask()
+                val formatKotlin = registerParentFormatTask()
+
+                sourceResolver.applyToAll(project) { id, resolveSources ->
+                    val ktLintParams = KtLintParams(
+                        kotlinterExtension.indentSize,
+                        kotlinterExtension.continuationIndentSize,
+                        kotlinterExtension.experimentalRules,
+                        kotlinterExtension.disabledRules,
+                        editorConfigPath()
+                    )
+
+                    val lintKotlinPerVariant = tasks.register("lintKotlin${id.capitalize()}", LintTask::class.java) { lintTask ->
+                        lintTask.source(resolveSources)
+                        lintTask.ignoreFailures = kotlinterExtension.ignoreFailures
+                        lintTask.reports = kotlinterExtension.reporters.associate { reporter ->
+                            reporter to reportFile("$id-lint.${reporterFileExtension(reporter)}")
+                        }
+                        lintTask.ktLintParams = ktLintParams
+                        lintTask.fileBatchSize = kotlinterExtension.fileBatchSize
+                    }
+                    lintKotlin.dependsOn(lintKotlinPerVariant)
+
+                    val formatKotlinPerVariant = tasks.register("formatKotlin${id.capitalize()}", FormatTask::class.java) { formatTask ->
+                        formatTask.source(resolveSources)
+                        formatTask.report = reportFile("$id-format.txt")
+                        formatTask.ktLintParams = ktLintParams
+                        formatTask.fileBatchSize = kotlinterExtension.fileBatchSize
+                    }
+                    formatKotlin.dependsOn(formatKotlinPerVariant)
                 }
-
-                taskCreator.createParentTasks()
-            }
-        }
-
-        project.afterEvaluate {
-            val ktLintParams = KtLintParams(
-                kotlinterExtension.indentSize,
-                kotlinterExtension.continuationIndentSize,
-                kotlinterExtension.experimentalRules,
-                kotlinterExtension.disabledRules,
-                project.editorConfigPath()
-            )
-
-            taskCreator.lintTasks.forEach { lintTask ->
-                lintTask.ignoreFailures = kotlinterExtension.ignoreFailures
-                lintTask.reports = kotlinterExtension.reporters.associate { reporter ->
-                    reporter to project.reportFile("${lintTask.sourceSetId}-lint.${reporterFileExtension(reporter)}")
-                }
-                lintTask.ktLintParams = ktLintParams
-                lintTask.fileBatchSize = kotlinterExtension.fileBatchSize
-            }
-            taskCreator.formatTasks.forEach { formatTask ->
-                formatTask.ktLintParams = ktLintParams
-                formatTask.fileBatchSize = kotlinterExtension.fileBatchSize
             }
         }
     }
-}
 
-class TaskCreator(private val project: Project) {
-
-    val formatTasks = mutableListOf<FormatTask>()
-    val lintTasks = mutableListOf<LintTask>()
-
-    fun createSourceSetTasks(id: String, files: Set<File>) {
-
-        formatTasks += project.tasks.create("formatKotlin${id.capitalize()}", FormatTask::class.java) {
-            it.source(files)
-            it.report = project.reportFile("$id-format.txt")
-        }
-
-        lintTasks += project.tasks.create("lintKotlin${id.capitalize()}", LintTask::class.java) {
-            it.source(files)
-            it.sourceSetId = id
-        }
-    }
-
-    fun createParentTasks() {
-        project.tasks.create("formatKotlin") {
-            it.group = "formatting"
-            it.description = "Formats the Kotlin source files."
-            it.dependsOn(formatTasks)
-        }
-
-        val lintKotlin = project.tasks.create("lintKotlin") {
+    private fun Project.registerParentLintTask() =
+        tasks.register("lintKotlin") {
             it.group = "formatting"
             it.description = "Runs lint on the Kotlin source files."
-            it.dependsOn(lintTasks)
+        }.also {
+            tasks.named("check").dependsOn(it)
         }
 
-        project.tasks.getByName("check") {
-            it.dependsOn(lintKotlin)
+    private fun Project.registerParentFormatTask() =
+        tasks.register("formatKotlin") {
+            it.group = "formatting"
+            it.description = "Formats the Kotlin source files."
         }
-    }
 }
 
-typealias SourceSetAction = (String, Set<File>) -> Unit
+internal typealias SourceSetAction = (String, Provider<FileTree>) -> Unit
 
 interface SourceSetResolver {
     fun applyToAll(project: Project, action: SourceSetAction)
 }
 
-object KotlinJvmSourceSetResolver : SourceSetResolver {
+internal object KotlinJvmSourceSetResolver : SourceSetResolver {
 
     override fun applyToAll(project: Project, action: SourceSetAction) {
         getSourceSets(project).all { sourceSet ->
-            getKotlinFiles(sourceSet)?.let { files ->
-                action(getSourceSetName(sourceSet)!!.id, files)
+            sourceSet.kotlin?.let { directorySet ->
+                action(directorySet.name.id, project.provider { directorySet })
             }
         }
     }
 
     private fun getSourceSets(project: Project): SourceSetContainer =
         project.convention.getPlugin(JavaPluginConvention::class.java).sourceSets
-
-    private fun getSourceSetName(sourceSet: SourceSet) = sourceSet.kotlin?.name
-
-    private fun getKotlinFiles(sourceSet: SourceSet) = sourceSet.kotlin?.files
 
     private val SourceSet.kotlin: SourceDirectorySet?
         get() = ((getConvention("kotlin") ?: getConvention("kotlin2js")) as? KotlinSourceSet)?.kotlin
@@ -131,35 +108,30 @@ object KotlinJvmSourceSetResolver : SourceSetResolver {
         (this as HasConvention).convention.plugins[name]
 }
 
-object AndroidSourceSetResolver : SourceSetResolver {
+internal object AndroidSourceSetResolver : SourceSetResolver {
 
     override fun applyToAll(project: Project, action: SourceSetAction) {
         val android = project.extensions.findByName("android")
         (android as? BaseExtension)?.let {
             it.sourceSets.all { sourceSet ->
                 val id = sourceSet.name.id
-                val files = getKotlinFiles(project, sourceSet)
-                if (files.isNotEmpty()) {
-                    action(id, files)
-                }
+                action(id, project.provider { getKotlinFiles(project, sourceSet) })
             }
         }
     }
 
     private fun getKotlinFiles(project: Project, sourceSet: AndroidSourceSet) = sourceSet.java.srcDirs.map { dir ->
-        project.fileTree(dir) {
-            it.include("**/*.kt")
-        }
+        project.fileTree(dir) { it.include("**/*.kt") }
     }.reduce { merged: FileTree, tree ->
-        merged.plus(tree)
-    }.files
+        merged + tree
+    }
 }
 
-val String.id
+internal val String.id
     get() = split(" ").first()
 
-fun Project.reportFile(name: String) = file("${project.buildDir}/reports/ktlint/$name")
+internal fun Project.reportFile(name: String) = file("$buildDir/reports/ktlint/$name")
 
-fun Project.editorConfigPath() = with(rootProject.file(".editorconfig")) {
+internal fun Project.editorConfigPath() = with(rootProject.file(".editorconfig")) {
     if (this.exists()) this.path else null
 }

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/LintTask.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/LintTask.kt
@@ -6,7 +6,6 @@ import org.gradle.api.GradleException
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
-import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputFiles
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
@@ -65,9 +64,6 @@ open class LintTask @Inject constructor(
         ktLintParams.editorConfigPath = editorConfigPath
     }
 
-    @Internal
-    var sourceSetId = ""
-
     @TaskAction
     fun run() {
         val hasErrorReporter = HasErrorReporter()
@@ -75,7 +71,8 @@ open class LintTask @Inject constructor(
             reporterFor(reporter, report)
         } + hasErrorReporter
         val executionContextRepository = ExecutionContextRepository.lintInstance
-        val executionContextRepositoryId = executionContextRepository.register(LintExecutionContext(defaultRuleSetProviders, reporters, logger))
+        val executionContextRepositoryId =
+            executionContextRepository.register(LintExecutionContext(defaultRuleSetProviders, reporters, logger))
 
         reporters.onEach { it.beforeAll() }
 

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/ExtensionTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/ExtensionTest.kt
@@ -4,11 +4,14 @@ import groovy.util.GroovyTestCase.assertEquals
 import java.io.File
 import org.gradle.testkit.runner.TaskOutcome
 import org.intellij.lang.annotations.Language
+import org.jmailen.gradle.kotlinter.functional.utils.kotlinClass
+import org.jmailen.gradle.kotlinter.functional.utils.resolve
+import org.jmailen.gradle.kotlinter.functional.utils.settingsFile
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
-internal class ExtensionTest : WithGradleTest() {
+internal class ExtensionTest : WithGradleTest.Kotlin() {
 
     lateinit var projectRoot: File
 
@@ -116,16 +119,4 @@ internal class ExtensionTest : WithGradleTest() {
             assertEquals(TaskOutcome.SUCCESS, task(":lintKotlinMain")?.outcome)
         }
     }
-
-    @Language("kotlin")
-    private fun kotlinClass(className: String) = """
-                object $className
-                
-            """.trimIndent()
-
-    @Language("groovy")
-    private val settingsFile = """
-        rootProject.name = 'kotlinter'
-        
-    """.trimIndent()
 }

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/ExtensionTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/ExtensionTest.kt
@@ -4,6 +4,7 @@ import groovy.util.GroovyTestCase.assertEquals
 import java.io.File
 import org.gradle.testkit.runner.TaskOutcome
 import org.intellij.lang.annotations.Language
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
@@ -93,7 +94,7 @@ internal class ExtensionTest : WithGradleTest() {
             assertEquals(TaskOutcome.SUCCESS, task(":lintKotlinMain")?.outcome)
         }
         val report = projectRoot.resolve("build/reports/ktlint/main-lint.html")
-        assert(report.exists())
+        assertTrue(report.readText().isNotEmpty())
     }
 
     @Test

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/ExtensionTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/ExtensionTest.kt
@@ -1,0 +1,130 @@
+package org.jmailen.gradle.kotlinter.functional
+
+import groovy.util.GroovyTestCase.assertEquals
+import java.io.File
+import org.gradle.testkit.runner.TaskOutcome
+import org.intellij.lang.annotations.Language
+import org.junit.Before
+import org.junit.Test
+
+internal class ExtensionTest : WithGradleTest() {
+
+    lateinit var projectRoot: File
+
+    @Before
+    fun setUp() {
+        projectRoot = testProjectDir.root.apply {
+            resolve("settings.gradle") { writeText(settingsFile) }
+            resolve("build.gradle") {
+                @Language("groovy")
+                val buildScript = """
+                plugins {
+                    id 'kotlin'
+                    id 'org.jmailen.kotlinter'
+                }
+                
+            """.trimIndent()
+                writeText(buildScript)
+            }
+        }
+    }
+
+    @Test
+    fun `extension configures ignoreFailures`() {
+        projectRoot.resolve("build.gradle") {
+            @Language("groovy")
+            val script = """
+                kotlinter {
+                    ignoreFailures = true
+                }
+            """.trimIndent()
+            appendText(script)
+        }
+        projectRoot.resolve("src/main/kotlin/FileName.kt") {
+            writeText(kotlinClass("DifferentClassName"))
+        }
+
+        build("lintKotlin").apply {
+            assertEquals(TaskOutcome.SUCCESS, task(":lintKotlinMain")?.outcome)
+        }
+    }
+
+    @Test
+    fun `extension configures indentSize`() {
+        projectRoot.resolve("build.gradle") {
+            @Language("groovy")
+            val script = """
+                kotlinter {
+                    indentSize = 2
+                }
+            """.trimIndent()
+            appendText(script)
+        }
+        projectRoot.resolve("src/main/kotlin/TwoSpaces.kt") {
+            writeText(
+                """ |
+                    |  object TwoSpaces
+                    |        
+                """.trimMargin()
+            )
+        }
+
+        build("lintKotlin").apply {
+            assertEquals(TaskOutcome.SUCCESS, task(":lintKotlinMain")?.outcome)
+        }
+    }
+
+    @Test
+    fun `extension configures reporters`() {
+        projectRoot.resolve("build.gradle") {
+            @Language("groovy")
+            val script = """
+                kotlinter {
+                    reporters = ['html'] 
+                }
+            """.trimIndent()
+            appendText(script)
+        }
+        projectRoot.resolve("src/main/kotlin/KotlinClass.kt") {
+            writeText(kotlinClass("KotlinClass"))
+        }
+
+        build("lintKotlin").apply {
+            assertEquals(TaskOutcome.SUCCESS, task(":lintKotlinMain")?.outcome)
+        }
+        val report = projectRoot.resolve("build/reports/ktlint/main-lint.html")
+        assert(report.exists())
+    }
+
+    @Test
+    fun `extension configures disabledRules`() {
+        projectRoot.resolve("build.gradle") {
+            @Language("groovy")
+            val script = """
+                kotlinter {
+                    disabledRules = ["filename"]
+                }
+            """.trimIndent()
+            appendText(script)
+        }
+        projectRoot.resolve("src/main/kotlin/FileName.kt") {
+            writeText(kotlinClass("DifferentClassName"))
+        }
+
+        build("lintKotlin").apply {
+            assertEquals(TaskOutcome.SUCCESS, task(":lintKotlinMain")?.outcome)
+        }
+    }
+
+    @Language("kotlin")
+    private fun kotlinClass(className: String) = """
+                object $className
+                
+            """.trimIndent()
+
+    @Language("groovy")
+    private val settingsFile = """
+        rootProject.name = 'kotlinter'
+        
+    """.trimIndent()
+}

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/FunctionalTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/FunctionalTest.kt
@@ -1,21 +1,15 @@
 package org.jmailen.gradle.kotlinter.functional
 
 import java.io.File
-import org.gradle.testkit.runner.BuildResult
-import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome.FAILED
 import org.gradle.testkit.runner.TaskOutcome.SUCCESS
+import org.intellij.lang.annotations.Language
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
-import org.junit.rules.TemporaryFolder
 
-class FunctionalTest {
-
-    @get:Rule
-    val testProjectDir = TemporaryFolder()
+internal class FunctionalTest : WithGradleTest() {
 
     private lateinit var settingsFile: File
     private lateinit var buildFile: File
@@ -87,23 +81,13 @@ class FunctionalTest {
         }
     }
 
-    private fun build(vararg args: String): BuildResult = gradleRunnerFor(*args).build()
-
-    private fun buildAndFail(vararg args: String): BuildResult = gradleRunnerFor(*args).buildAndFail()
-
-    private fun gradleRunnerFor(vararg args: String): GradleRunner {
-        return GradleRunner.create()
-            .withProjectDir(testProjectDir.root)
-            .withArguments(args.toList() + "--stacktrace")
-            .withPluginClasspath()
-    }
-
     private fun settingsFile() = settingsFile.apply {
         writeText("rootProject.name = 'kotlinter'")
     }
 
     private fun buildFile() = buildFile.apply {
-        writeText("""
+        @Language("groovy")
+        val buildscript = """
             plugins {
                 id 'org.jetbrains.kotlin.jvm' version '1.3.41'
                 id 'org.jmailen.kotlinter'
@@ -124,7 +108,8 @@ class FunctionalTest {
                 disabledRules = ["final-newline"]
                 editorConfigPath = project.rootProject.file(".editorconfig")
             }
-        """.trimIndent())
+        """.trimIndent()
+        writeText(buildscript)
     }
 
     private fun kotlinSourceFile(name: String, content: String) = File(sourceDir, name).apply {

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/KotlinProjectTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/KotlinProjectTest.kt
@@ -9,7 +9,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
-internal class FunctionalTest : WithGradleTest() {
+internal class KotlinProjectTest : WithGradleTest.Kotlin() {
 
     private lateinit var settingsFile: File
     private lateinit var buildFile: File
@@ -78,6 +78,20 @@ internal class FunctionalTest : WithGradleTest() {
 
         build("ktLint").apply {
             assertEquals(SUCCESS, task(":ktLint")?.outcome)
+        }
+    }
+
+    @Test
+    fun `check task runs lintFormat`() {
+        settingsFile()
+        buildFile()
+        kotlinSourceFile("CustomObject.kt", """
+            object CustomObject
+            
+        """.trimIndent())
+
+        build("check").apply {
+            assertEquals(SUCCESS, task(":lintKotlin")?.outcome)
         }
     }
 

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/ModifiedSourceSetsTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/ModifiedSourceSetsTest.kt
@@ -51,6 +51,17 @@ internal class ModifiedSourceSetsTest : WithGradleTest.Android() {
                                 main.java.srcDirs += "src/main/kotlin"
                                 test.java.srcDirs += "src/test/kotlin"
                                 debug.java.srcDirs += "src/debug/kotlin"
+                                flavorOne.java.srcDirs = ['src/customFolder/kotlin']
+                            }
+                            
+                            flavorDimensions 'customFlavor'
+                            productFlavors {
+                                flavorOne {
+                                    dimension 'customFlavor'
+                                }
+                                flavorTwo {
+                                    dimension 'customFlavor'
+                                }
                             }
                         }
                         
@@ -69,6 +80,9 @@ internal class ModifiedSourceSetsTest : WithGradleTest.Android() {
                 resolve("src/test/kotlin/TestSourceSet.kt") {
                     writeText(kotlinClass("TestSourceSet"))
                 }
+                resolve("src/customFolder/kotlin/CustomSourceSet.kt") {
+                    writeText(kotlinClass("CustomSourceSet"))
+                }
             }
             kotlinModuleRoot = resolve("kotlinproject") {
                 resolve("build.gradle") {
@@ -81,6 +95,9 @@ internal class ModifiedSourceSetsTest : WithGradleTest.Android() {
                         
                         sourceSets {
                             main.kotlin.srcDirs += "random/path"
+                            individuallyCustomized {
+                                java.srcDirs = ["src/debug/kotlin"]
+                            }
                         }
                     """.trimIndent()
                     writeText(kotlinBuildScript)
@@ -90,6 +107,9 @@ internal class ModifiedSourceSetsTest : WithGradleTest.Android() {
                 }
                 resolve("src/test/kotlin/TestSourceSet.kt") {
                     writeText(kotlinClass("TestSourceSet"))
+                }
+                resolve("src/individuallyCustomized/kotlin/CustomSourceSet.kt") {
+                    writeText(kotlinClass("CustomSourceSet"))
                 }
             }
         }
@@ -101,9 +121,11 @@ internal class ModifiedSourceSetsTest : WithGradleTest.Android() {
             assertEquals(TaskOutcome.SUCCESS, task(":androidproject:lintKotlinMain")?.outcome)
             assertEquals(TaskOutcome.SUCCESS, task(":androidproject:lintKotlinDebug")?.outcome)
             assertEquals(TaskOutcome.SUCCESS, task(":androidproject:lintKotlinTest")?.outcome)
+            assertEquals(TaskOutcome.SUCCESS, task(":androidproject:lintKotlinFlavorOne")?.outcome)
             assertEquals(TaskOutcome.SUCCESS, task(":androidproject:lintKotlin")?.outcome)
             assertEquals(TaskOutcome.SUCCESS, task(":kotlinproject:lintKotlinMain")?.outcome)
             assertEquals(TaskOutcome.SUCCESS, task(":kotlinproject:lintKotlinTest")?.outcome)
+            assertEquals(TaskOutcome.SUCCESS, task(":kotlinproject:lintKotlinIndividuallyCustomized")?.outcome)
         }
     }
 
@@ -115,9 +137,11 @@ internal class ModifiedSourceSetsTest : WithGradleTest.Android() {
             assertEquals(TaskOutcome.UP_TO_DATE, task(":androidproject:lintKotlinMain")?.outcome)
             assertEquals(TaskOutcome.UP_TO_DATE, task(":androidproject:lintKotlinDebug")?.outcome)
             assertEquals(TaskOutcome.UP_TO_DATE, task(":androidproject:lintKotlinTest")?.outcome)
+            assertEquals(TaskOutcome.UP_TO_DATE, task(":androidproject:lintKotlinFlavorOne")?.outcome)
             assertEquals(TaskOutcome.UP_TO_DATE, task(":androidproject:lintKotlin")?.outcome)
             assertEquals(TaskOutcome.UP_TO_DATE, task(":kotlinproject:lintKotlinMain")?.outcome)
             assertEquals(TaskOutcome.UP_TO_DATE, task(":kotlinproject:lintKotlinTest")?.outcome)
+            assertEquals(TaskOutcome.UP_TO_DATE, task(":kotlinproject:lintKotlinIndividuallyCustomized")?.outcome)
         }
     }
 

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/ModifiedSourceSetsTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/ModifiedSourceSetsTest.kt
@@ -1,0 +1,138 @@
+package org.jmailen.gradle.kotlinter.functional
+
+import java.io.File
+import org.gradle.testkit.runner.TaskOutcome
+import org.intellij.lang.annotations.Language
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+internal class ModifiedSourceSetsTest : WithGradleTest() {
+
+    private lateinit var androidModuleRoot: File
+    private lateinit var kotlinModuleRoot: File
+
+    @Before
+    fun setUp() {
+        testProjectDir.root.apply {
+            resolve("settings.gradle") { writeText(settingsFile) }
+            resolve("build.gradle") {
+                @Language("groovy")
+                val buildScript = """
+                subprojects {
+                    repositories {
+                        google()
+                        jcenter()
+                    }
+                }
+                
+            """.trimIndent()
+                writeText(buildScript)
+            }
+            androidModuleRoot = resolve("androidproject") {
+                resolve("build.gradle") {
+                    @Language("groovy")
+                    val androidBuildScript = """
+                        plugins {
+                            id 'com.android.library'
+                            id 'kotlin-android'
+                            id 'org.jmailen.kotlinter'
+                        }
+                        
+                        android {
+                            compileSdkVersion 29
+                            defaultConfig {
+                                minSdkVersion 23
+                            }
+                            sourceSets {
+                                main.java.srcDirs += "src/main/kotlin"
+                                test.java.srcDirs += "src/test/kotlin"
+                                debug.java.srcDirs += "src/debug/kotlin"
+                            }
+                        }
+                        
+                    """.trimIndent()
+                    writeText(androidBuildScript)
+                }
+                resolve("src/main/AndroidManifest.xml") {
+                    writeText(androidManifest)
+                }
+                resolve("src/main/kotlin/MainSourceSet.kt") {
+                    writeText(kotlinClass("MainSourceSet"))
+                }
+                resolve("src/debug/kotlin/DebugSourceSet.kt") {
+                    writeText(kotlinClass("DebugSourceSet"))
+                }
+                resolve("src/test/kotlin/TestSourceSet.kt") {
+                    writeText(kotlinClass("TestSourceSet"))
+                }
+            }
+            kotlinModuleRoot = resolve("kotlinproject") {
+                resolve("build.gradle") {
+                    @Language("groovy")
+                    val kotlinBuildScript = """
+                        plugins {
+                            id 'kotlin'
+                            id 'org.jmailen.kotlinter'
+                        }
+                        
+                        sourceSets {
+                            main.kotlin.srcDirs += "random/path"
+                        }
+                    """.trimIndent()
+                    writeText(kotlinBuildScript)
+                }
+                resolve("random/path/MainSourceSet.kt") {
+                    writeText(kotlinClass("MainSourceSet"))
+                }
+                resolve("src/test/kotlin/TestSourceSet.kt") {
+                    writeText(kotlinClass("TestSourceSet"))
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `kotlinter detects sources in all sourcesets`() {
+        build("lintKotlin").apply {
+            assertEquals(TaskOutcome.SUCCESS, task(":androidproject:lintKotlinMain")?.outcome)
+            assertEquals(TaskOutcome.SUCCESS, task(":androidproject:lintKotlinDebug")?.outcome)
+            assertEquals(TaskOutcome.SUCCESS, task(":androidproject:lintKotlinTest")?.outcome)
+            assertEquals(TaskOutcome.SUCCESS, task(":androidproject:lintKotlin")?.outcome)
+            assertEquals(TaskOutcome.SUCCESS, task(":kotlinproject:lintKotlinMain")?.outcome)
+            assertEquals(TaskOutcome.SUCCESS, task(":kotlinproject:lintKotlinTest")?.outcome)
+        }
+    }
+
+    @Test
+    fun `kotlinter becomes up-to-date on second run`() {
+        build("lintKotlin")
+
+        build("lintKotlin").apply {
+            assertEquals(TaskOutcome.UP_TO_DATE, task(":androidproject:lintKotlinMain")?.outcome)
+            assertEquals(TaskOutcome.UP_TO_DATE, task(":androidproject:lintKotlinDebug")?.outcome)
+            assertEquals(TaskOutcome.UP_TO_DATE, task(":androidproject:lintKotlinTest")?.outcome)
+            assertEquals(TaskOutcome.UP_TO_DATE, task(":androidproject:lintKotlin")?.outcome)
+            assertEquals(TaskOutcome.UP_TO_DATE, task(":kotlinproject:lintKotlinMain")?.outcome)
+            assertEquals(TaskOutcome.UP_TO_DATE, task(":kotlinproject:lintKotlinTest")?.outcome)
+        }
+    }
+
+    @Language("kotlin")
+    private fun kotlinClass(className: String) = """
+                object $className
+                
+            """.trimIndent()
+
+    @Language("groovy")
+    private val settingsFile = """
+        rootProject.name = 'kotlinter'
+        include 'androidproject', 'kotlinproject'
+    """.trimIndent()
+
+    @Language("xml")
+    private val androidManifest = """
+         <manifest package="com.example" />
+    
+    """.trimIndent()
+}

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/ModifiedSourceSetsTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/ModifiedSourceSetsTest.kt
@@ -3,11 +3,14 @@ package org.jmailen.gradle.kotlinter.functional
 import java.io.File
 import org.gradle.testkit.runner.TaskOutcome
 import org.intellij.lang.annotations.Language
+import org.jmailen.gradle.kotlinter.functional.utils.androidManifest
+import org.jmailen.gradle.kotlinter.functional.utils.kotlinClass
+import org.jmailen.gradle.kotlinter.functional.utils.resolve
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 
-internal class ModifiedSourceSetsTest : WithGradleTest() {
+internal class ModifiedSourceSetsTest : WithGradleTest.Android() {
 
     private lateinit var androidModuleRoot: File
     private lateinit var kotlinModuleRoot: File
@@ -118,21 +121,9 @@ internal class ModifiedSourceSetsTest : WithGradleTest() {
         }
     }
 
-    @Language("kotlin")
-    private fun kotlinClass(className: String) = """
-                object $className
-                
-            """.trimIndent()
-
     @Language("groovy")
     private val settingsFile = """
         rootProject.name = 'kotlinter'
         include 'androidproject', 'kotlinproject'
-    """.trimIndent()
-
-    @Language("xml")
-    private val androidManifest = """
-         <manifest package="com.example" />
-    
     """.trimIndent()
 }

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/WithGradleTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/WithGradleTest.kt
@@ -1,0 +1,31 @@
+package org.jmailen.gradle.kotlinter.functional
+
+import java.io.File
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+
+internal abstract class WithGradleTest {
+
+    @get:Rule
+    val testProjectDir = TemporaryFolder()
+
+    protected fun build(vararg args: String): BuildResult = gradleRunnerFor(*args).build()
+
+    protected fun buildAndFail(vararg args: String): BuildResult = gradleRunnerFor(*args).buildAndFail()
+
+    private fun gradleRunnerFor(vararg args: String): GradleRunner {
+        return GradleRunner.create()
+            .withProjectDir(testProjectDir.root)
+            .withArguments(args.toList() + "--stacktrace")
+            .forwardOutput()
+            .withPluginClasspath()
+    }
+
+    protected fun File.resolve(path: String, receiver: File.() -> Unit): File =
+        resolve(path).apply {
+            parentFile.mkdirs()
+            receiver()
+        }
+}

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/WithGradleTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/WithGradleTest.kt
@@ -1,12 +1,13 @@
 package org.jmailen.gradle.kotlinter.functional
 
-import java.io.File
+import org.gradle.internal.classpath.DefaultClassPath
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.internal.PluginUnderTestMetadataReading
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 
-internal abstract class WithGradleTest {
+abstract class WithGradleTest {
 
     @get:Rule
     val testProjectDir = TemporaryFolder()
@@ -15,17 +16,35 @@ internal abstract class WithGradleTest {
 
     protected fun buildAndFail(vararg args: String): BuildResult = gradleRunnerFor(*args).buildAndFail()
 
-    private fun gradleRunnerFor(vararg args: String): GradleRunner {
-        return GradleRunner.create()
-            .withProjectDir(testProjectDir.root)
-            .withArguments(args.toList() + "--stacktrace")
-            .forwardOutput()
-            .withPluginClasspath()
+    protected abstract fun gradleRunnerFor(vararg args: String): GradleRunner
+
+    abstract class Android : WithGradleTest() {
+
+        override fun gradleRunnerFor(vararg args: String): GradleRunner {
+            return defaultRunner(*args)
+                .withPluginClasspath()
+        }
     }
 
-    protected fun File.resolve(path: String, receiver: File.() -> Unit): File =
-        resolve(path).apply {
-            parentFile.mkdirs()
-            receiver()
+    abstract class Kotlin : WithGradleTest() {
+
+        override fun gradleRunnerFor(vararg args: String): GradleRunner {
+            val classpath = DefaultClassPath.of(PluginUnderTestMetadataReading.readImplementationClasspath()).asFiles
+            val androidDependencies = listOf(
+                ".*/com\\.android\\..*/.*".toRegex(),
+                ".*/androidx\\..*/.*".toRegex(),
+                ".*/com\\.google\\..*/.*".toRegex()
+            )
+            val noAndroid = classpath.filterNot { dependency -> androidDependencies.any { it.matches(dependency.path) } }
+
+            return defaultRunner(*args)
+                .withPluginClasspath(noAndroid)
         }
+    }
 }
+
+private fun WithGradleTest.defaultRunner(vararg args: String) =
+    GradleRunner.create()
+        .withProjectDir(testProjectDir.root)
+        .withArguments(args.toList() + "--stacktrace")
+        .forwardOutput()

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/utils/Factories.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/utils/Factories.kt
@@ -1,0 +1,21 @@
+package org.jmailen.gradle.kotlinter.functional.utils
+
+import org.intellij.lang.annotations.Language
+
+@Language("kotlin")
+internal fun kotlinClass(className: String) = """
+    object $className
+    
+""".trimIndent()
+
+@Language("groovy")
+internal val settingsFile = """
+    rootProject.name = 'kotlinter'
+    
+""".trimIndent()
+
+@Language("xml")
+internal val androidManifest = """
+     <manifest package="com.example" />
+
+""".trimIndent()

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/utils/Utilities.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/utils/Utilities.kt
@@ -1,0 +1,9 @@
+package org.jmailen.gradle.kotlinter.functional.utils
+
+import java.io.File
+
+internal fun File.resolve(path: String, receiver: File.() -> Unit): File =
+    resolve(path).apply {
+        parentFile.mkdirs()
+        receiver()
+    }

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/support/RuleSetsTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/support/RuleSetsTest.kt
@@ -64,5 +64,9 @@ class TestRuleSetProvider(val ruleSet: RuleSet) : RuleSetProvider {
 }
 
 class TestRule(id: String) : Rule(id) {
-    override fun visit(node: ASTNode, autoCorrect: Boolean, emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit) {}
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+    ) {}
 }


### PR DESCRIPTION
Fixes #115

I let myself not only to lazily evaluate sources, but also to enable lazy task configuration.

I hope that addresses: 
>I think it's fixable if we use a gradle Provider or Closure to provide the final srcDirs as use time instead of configuration time

mentioned https://github.com/jeremymailen/kotlinter-gradle/issues/115#issuecomment-522457021

However, when delaying sources configuration we have to create tasks that weren't previously created when source set was empty. So that would be slight behavior change and I couldn't figure out a way of not creating those. Although, that shouldn't be an issue as those tasks are `NO_SOURCE` so they are not executed.