### PR TITLE
Make links clickable

### DIFF
--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/format/FormatWorkerRunnable.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/format/FormatWorkerRunnable.kt
@@ -43,16 +43,15 @@ class FormatWorkerRunnable @Inject constructor(
                 }?.let { formatFunc ->
                     val ruleSets = resolveRuleSets(executionContext.ruleSetProviders, ktLintParams.experimentalRules)
                     val formattedText = formatFunc.invoke(file, ruleSets) { error, corrected ->
-                        val errorStr = "${file.path}:${error.line}:${error.col}: [${error.ruleId}] ${error.detail}"
                         val msg = when (corrected) {
-                            true -> "Format fixed > $errorStr"
-                            false -> "Format could not fix > $errorStr"
+                            true -> "${file.path}:${error.line}:${error.col}: Format fixed > [${error.ruleId}] ${error.detail}"
+                            false -> "${file.path}:${error.line}:${error.col}: Format could not fix > [${error.ruleId}] ${error.detail}"
                         }
                         logger.log(LogLevel.QUIET, msg)
                         executionContext.fixes.add(msg)
                     }
                     if (!formattedText.contentEquals(sourceText)) {
-                        logger.log(LogLevel.QUIET, "Format fixed > ${file.path}:")
+                        logger.log(LogLevel.QUIET, "${file.path}: Format fixed")
                         file.writeText(formattedText)
                     }
                 }

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/format/FormatWorkerRunnable.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/format/FormatWorkerRunnable.kt
@@ -43,16 +43,16 @@ class FormatWorkerRunnable @Inject constructor(
                 }?.let { formatFunc ->
                     val ruleSets = resolveRuleSets(executionContext.ruleSetProviders, ktLintParams.experimentalRules)
                     val formattedText = formatFunc.invoke(file, ruleSets) { error, corrected ->
-                        val errorStr = "$relativePath:${error.line}:${error.col}: [${error.ruleId}] ${error.detail}"
+                        val errorStr = "$${file.path}:${error.line}:${error.col}: [${error.ruleId}] ${error.detail}"
                         val msg = when (corrected) {
-                            true -> "Format fixed > $projectDirectory${File.separator}$errorStr"
-                            false -> "Format could not fix > $projectDirectory${File.separator}$errorStr"
+                            true -> "Format fixed > $errorStr"
+                            false -> "Format could not fix > $errorStr"
                         }
                         logger.log(LogLevel.QUIET, msg)
                         executionContext.fixes.add(msg)
                     }
                     if (!formattedText.contentEquals(sourceText)) {
-                        logger.log(LogLevel.QUIET, "Format fixed > $relativePath")
+                        logger.log(LogLevel.QUIET, "Format fixed > ${file.path}:")
                         file.writeText(formattedText)
                     }
                 }

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/format/FormatWorkerRunnable.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/format/FormatWorkerRunnable.kt
@@ -45,8 +45,8 @@ class FormatWorkerRunnable @Inject constructor(
                     val formattedText = formatFunc.invoke(file, ruleSets) { error, corrected ->
                         val errorStr = "$relativePath:${error.line}:${error.col}: [${error.ruleId}] ${error.detail}"
                         val msg = when (corrected) {
-                            true -> "Format fixed > $errorStr"
-                            false -> "Format could not fix > $errorStr"
+                            true -> "Format fixed > $projectDirectory${File.separator}$errorStr"
+                            false -> "Format could not fix > $projectDirectory${File.separator}$errorStr"
                         }
                         logger.log(LogLevel.QUIET, msg)
                         executionContext.fixes.add(msg)

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/format/FormatWorkerRunnable.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/format/FormatWorkerRunnable.kt
@@ -43,7 +43,7 @@ class FormatWorkerRunnable @Inject constructor(
                 }?.let { formatFunc ->
                     val ruleSets = resolveRuleSets(executionContext.ruleSetProviders, ktLintParams.experimentalRules)
                     val formattedText = formatFunc.invoke(file, ruleSets) { error, corrected ->
-                        val errorStr = "$${file.path}:${error.line}:${error.col}: [${error.ruleId}] ${error.detail}"
+                        val errorStr = "${file.path}:${error.line}:${error.col}: [${error.ruleId}] ${error.detail}"
                         val msg = when (corrected) {
                             true -> "Format fixed > $errorStr"
                             false -> "Format could not fix > $errorStr"

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/lint/LintWorkerRunnable.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/lint/LintWorkerRunnable.kt
@@ -46,8 +46,8 @@ class LintWorkerRunnable @Inject constructor(
                 lintFunc?.invoke(file, ruleSets) { error ->
                     reporters.onEach { it.onLintError(relativePath, error, false) }
 
-                    val errorStr = "$relativePath:${error.line}:${error.col}: [${error.ruleId}] ${error.detail}"
-                    logger.quiet("Lint error > $projectDirectory${File.separator}$errorStr")
+                    val errorStr = "$${file.path}:${error.line}:${error.col}: [${error.ruleId}] ${error.detail}"
+                    logger.quiet("Lint error > $errorStr")
                 }
 
                 reporters.onEach { it.after(relativePath) }

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/lint/LintWorkerRunnable.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/lint/LintWorkerRunnable.kt
@@ -46,7 +46,7 @@ class LintWorkerRunnable @Inject constructor(
                 lintFunc?.invoke(file, ruleSets) { error ->
                     reporters.onEach { it.onLintError(relativePath, error, false) }
 
-                    val errorStr = "$${file.path}:${error.line}:${error.col}: [${error.ruleId}] ${error.detail}"
+                    val errorStr = "${file.path}:${error.line}:${error.col}: [${error.ruleId}] ${error.detail}"
                     logger.quiet("Lint error > $errorStr")
                 }
 

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/lint/LintWorkerRunnable.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/lint/LintWorkerRunnable.kt
@@ -47,7 +47,7 @@ class LintWorkerRunnable @Inject constructor(
                     reporters.onEach { it.onLintError(relativePath, error, false) }
 
                     val errorStr = "$relativePath:${error.line}:${error.col}: [${error.ruleId}] ${error.detail}"
-                    logger.quiet("Lint error > $errorStr")
+                    logger.quiet("Lint error > $projectDirectory${File.separator}$errorStr")
                 }
 
                 reporters.onEach { it.after(relativePath) }

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/lint/LintWorkerRunnable.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/lint/LintWorkerRunnable.kt
@@ -46,8 +46,8 @@ class LintWorkerRunnable @Inject constructor(
                 lintFunc?.invoke(file, ruleSets) { error ->
                     reporters.onEach { it.onLintError(relativePath, error, false) }
 
-                    val errorStr = "${file.path}:${error.line}:${error.col}: [${error.ruleId}] ${error.detail}"
-                    logger.quiet("Lint error > $errorStr")
+                    val errorStr = "${file.path}:${error.line}:${error.col}: Lint error > [${error.ruleId}] ${error.detail}"
+                    logger.quiet(errorStr)
                 }
 
                 reporters.onEach { it.after(relativePath) }

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/KotlinProjectTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/KotlinProjectTest.kt
@@ -40,9 +40,9 @@ internal class KotlinProjectTest : WithGradleTest.Kotlin() {
         )
 
         buildAndFail("lintKotlinMain").apply {
-            assertTrue(output.contains("Lint error >.*$className.kt.*Missing spacing before \"\\{\"".toRegex()))
-            assertTrue(output.contains("Lint error >.*$className.kt.*Unexpected spacing before \"\\(\"".toRegex()))
-            output.lines().filter { it.startsWith("Lint error") }.forEach { line ->
+            assertTrue(output.contains(".*$className.kt.* Lint error > \\[.*] Missing spacing before \"\\{\"".toRegex()))
+            assertTrue(output.contains(".*$className.kt.* Lint error > \\[.*] Unexpected spacing before \"\\(\"".toRegex()))
+            output.lines().filter { it.contains("Lint error") }.forEach { line ->
                 val filePath = pathPattern.find(line)?.groups?.get(1)?.value.orEmpty()
                 assertTrue(File(filePath).exists())
             }
@@ -87,7 +87,7 @@ internal class KotlinProjectTest : WithGradleTest.Kotlin() {
 
         build("formatKotlin").apply {
             assertEquals(SUCCESS, task(":formatKotlinMain")?.outcome)
-            output.lines().filter { it.startsWith("Format could not fix") }.forEach { line ->
+            output.lines().filter { it.contains("Format could not fix") }.forEach { line ->
                 val filePath = pathPattern.find(line)?.groups?.get(1)?.value.orEmpty()
                 assertTrue(File(filePath).exists())
             }


### PR DESCRIPTION
I would like to suggest small improvement which allows user to simply click the link to file containing code style error as on following gif:
 
### `lintKotlin`:
![Kapture 2020-01-19 at 2 14 47](https://user-images.githubusercontent.com/36954793/72672986-cafd6980-3a63-11ea-890a-2309a10aef95.gif)

### `formatKotlin`:
![image](https://user-images.githubusercontent.com/36954793/72673217-8c69ae00-3a67-11ea-81fc-6a852906037c.png)
**update**:
the `Format Fixed` message should have clickable link too. 
![image](https://user-images.githubusercontent.com/36954793/72690419-9ac5d180-3b1c-11ea-924d-5247c8ce9dd2.png)

Related `ktlint` issue:
https://github.com/pinterest/ktlint/issues/560