### PR TITLE
Convert from groovy to kotlin dsl for build #126

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,10 @@
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '1.3.60'
-    id 'com.gradle.plugin-publish' version '0.10.1'
-    id 'java-gradle-plugin'
-    id 'maven-publish'
-    id 'org.jmailen.kotlinter' version '2.1.3'
-    id 'idea'
+    id("org.jetbrains.kotlin.jvm") version "1.3.61"
+    id("com.gradle.plugin-publish") version "0.10.1"
+    id("java-gradle-plugin")
+    id("maven-publish")
+    id("org.jmailen.kotlinter") version "2.1.3"
+    id("idea")
 }
 
 repositories {
@@ -12,23 +12,23 @@ repositories {
     google()
 }
 
-def ktlintVers = '0.36.0'
+def ktlintVers = "0.36.0"
 
 dependencies {
-    implementation "com.pinterest.ktlint:ktlint-core:$ktlintVers"
-    implementation "com.pinterest.ktlint:ktlint-reporter-checkstyle:$ktlintVers"
-    implementation "com.pinterest.ktlint:ktlint-reporter-json:$ktlintVers"
-    implementation "com.pinterest.ktlint:ktlint-reporter-html:$ktlintVers"
-    implementation "com.pinterest.ktlint:ktlint-reporter-plain:$ktlintVers"
-    implementation "com.pinterest.ktlint:ktlint-ruleset-experimental:$ktlintVers"
-    implementation "com.pinterest.ktlint:ktlint-ruleset-standard:$ktlintVers"
+    implementation("com.pinterest.ktlint:ktlint-core:$ktlintVers")
+    implementation("com.pinterest.ktlint:ktlint-reporter-checkstyle:$ktlintVers")
+    implementation("com.pinterest.ktlint:ktlint-reporter-json:$ktlintVers")
+    implementation("com.pinterest.ktlint:ktlint-reporter-html:$ktlintVers")
+    implementation("com.pinterest.ktlint:ktlint-reporter-plain:$ktlintVers")
+    implementation("com.pinterest.ktlint:ktlint-ruleset-experimental:$ktlintVers")
+    implementation("com.pinterest.ktlint:ktlint-ruleset-standard:$ktlintVers")
 
-    compileOnly 'org.jetbrains.kotlin:kotlin-gradle-plugin'
-    compileOnly 'com.android.tools.build:gradle:3.5.3'
+    compileOnly("org.jetbrains.kotlin:kotlin-gradle-plugin")
+    compileOnly("com.android.tools.build:gradle:3.5.3")
 
-    testImplementation 'junit:junit:4.13'
-    testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0'
-    testImplementation 'org.jetbrains:annotations:18.0.0'
+    testImplementation("junit:junit:4.13")
+    testImplementation("com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0")
+    testImplementation("org.jetbrains:annotations:18.0.0")
 }
 
 // Required to put all `compileOnly` dependencies on the classpath for the functional test suite
@@ -36,29 +36,29 @@ tasks.withType(PluginUnderTestMetadata).configureEach {
     pluginClasspath.from(configurations.compileOnly)
 }
 
-version = '2.3.0'
-group = 'org.jmailen.gradle'
-def pluginId = 'org.jmailen.kotlinter'
+version = "2.3.0"
+group = "org.jmailen.gradle"
+def pluginId = "org.jmailen.kotlinter"
 
 gradlePlugin {
     plugins {
         kotlinterPlugin {
             id = pluginId
-            implementationClass = 'org.jmailen.gradle.kotlinter.KotlinterPlugin'
+            implementationClass = "org.jmailen.gradle.kotlinter.KotlinterPlugin"
         }
     }
 }
 
 pluginBundle {
-    website = 'https://github.com/jeremymailen/kotlinter-gradle'
-    vcsUrl = 'https://github.com/jeremymailen/kotlinter-gradle'
-    tags = ['kotlin', 'ktlint', 'lint', 'format', 'style', 'android']
+    website = "https://github.com/jeremymailen/kotlinter-gradle"
+    vcsUrl = "https://github.com/jeremymailen/kotlinter-gradle"
+    tags = ["kotlin", "ktlint", "lint", "format", "style", "android"]
 
     plugins {
         kotlinterPlugin {
             id = pluginId
-            displayName = 'Kotlin Lint plugin'
-            description = 'Lint and formatting for Kotlin using ktlint with configuration-free setup on JVM and Android projects'
+            displayName = "Kotlin Lint plugin"
+            description = "Lint and formatting for Kotlin using ktlint with configuration-free setup on JVM and Android projects"
         }
     }
 }
@@ -76,5 +76,5 @@ publishing {
 }
 
 wrapper {
-    gradleVersion = '6.0.1'
+    gradleVersion = "6.0.1"
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,15 @@ repositories {
     google()
 }
 
+val pluginId = "org.jmailen.kotlinter"
+val githubUrl ="https://github.com/jeremymailen/kotlinter-gradle"
+val webUrl = "https://github.com/jeremymailen/kotlinter-gradle"
+val projectDescription = "Lint and formatting for Kotlin using ktlint with configuration-free setup on JVM and Android projects"
+
+version = "2.3.0"
+group = "org.jmailen.gradle"
+description = projectDescription
+
 dependencies {
     implementation("com.pinterest.ktlint:ktlint-core:${Versions.ktlint}")
     implementation("com.pinterest.ktlint:ktlint-reporter-checkstyle:${Versions.ktlint}")
@@ -36,9 +45,21 @@ tasks.withType<PluginUnderTestMetadata>().configureEach {
     pluginClasspath.from(configurations.compileOnly)
 }
 
-version = "2.3.0"
-group = "org.jmailen.gradle"
-val pluginId = "org.jmailen.kotlinter"
+val sourcesJar by tasks.registering(Jar::class) {
+    dependsOn(JavaPlugin.CLASSES_TASK_NAME)
+    group = JavaBasePlugin.DOCUMENTATION_GROUP
+    description = "Assembles sources JAR"
+    classifier = "sources"
+    from(sourceSets.main.get().allSource)
+}
+
+val javadocJar by tasks.registering(Jar::class) {
+    dependsOn(JavaPlugin.JAVADOC_TASK_NAME)
+    group = JavaBasePlugin.DOCUMENTATION_GROUP
+    description = "Assembles javaDoc JAR"
+    classifier = "javadoc"
+    from(tasks["javadoc"])
+}
 
 gradlePlugin {
     plugins {
@@ -50,29 +71,52 @@ gradlePlugin {
 }
 
 pluginBundle {
-    website = "https://github.com/jeremymailen/kotlinter-gradle"
-    vcsUrl = "https://github.com/jeremymailen/kotlinter-gradle"
+    website = webUrl
+    vcsUrl = githubUrl
+    description = project.description
     tags = listOf("kotlin", "ktlint", "lint", "format", "style", "android")
 
     plugins {
         named("kotlinterPlugin") {
-            id = pluginId
             displayName = "Kotlin Lint plugin"
-            description = "Lint and formatting for Kotlin using ktlint with configuration-free setup on JVM and Android projects"
         }
     }
 }
 
-val sourcesJar by tasks.registering(Jar::class) {
-    dependsOn(JavaPlugin.CLASSES_TASK_NAME)
-    group = JavaBasePlugin.DOCUMENTATION_GROUP
-    description = "Assembles sources JAR"
-    from(sourceSets.main.get().allSource)
+artifacts {
+    add(configurations.archives.name, sourcesJar)
+    add(configurations.archives.name, javadocJar)
 }
 
 publishing {
     publications.withType<MavenPublication> {
         artifact(sourcesJar.get())
+
+        pom {
+            name.set(project.name)
+            description.set(project.description)
+            url.set(webUrl)
+
+            scm {
+                url.set(githubUrl)
+            }
+
+            licenses {
+                license {
+                    name.set("The Apache Software License, Version 2.0")
+                    url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+                    distribution.set("repo")
+                }
+            }
+
+            developers {
+                developer {
+                    id.set("jeremymailen")
+                    name.set("Jeremy Mailen")
+                }
+            }
+        }
+
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,11 +1,11 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    kotlin("jvm") version "1.3.61"
-    id("com.gradle.plugin-publish") version "0.10.1"
+    kotlin("jvm") version Versions.kotlin
+    id("com.gradle.plugin-publish") version Versions.pluginPublish
     `java-gradle-plugin`
     `maven-publish`
-    id("org.jmailen.kotlinter") version "2.1.3"
+    id("org.jmailen.kotlinter") version Versions.kotlinter
     `idea`
 }
 
@@ -14,23 +14,21 @@ repositories {
     google()
 }
 
-val ktlintVers = "0.36.0"
-
 dependencies {
-    implementation("com.pinterest.ktlint:ktlint-core:$ktlintVers")
-    implementation("com.pinterest.ktlint:ktlint-reporter-checkstyle:$ktlintVers")
-    implementation("com.pinterest.ktlint:ktlint-reporter-json:$ktlintVers")
-    implementation("com.pinterest.ktlint:ktlint-reporter-html:$ktlintVers")
-    implementation("com.pinterest.ktlint:ktlint-reporter-plain:$ktlintVers")
-    implementation("com.pinterest.ktlint:ktlint-ruleset-experimental:$ktlintVers")
-    implementation("com.pinterest.ktlint:ktlint-ruleset-standard:$ktlintVers")
+    implementation("com.pinterest.ktlint:ktlint-core:${Versions.ktlint}")
+    implementation("com.pinterest.ktlint:ktlint-reporter-checkstyle:${Versions.ktlint}")
+    implementation("com.pinterest.ktlint:ktlint-reporter-json:${Versions.ktlint}")
+    implementation("com.pinterest.ktlint:ktlint-reporter-html:${Versions.ktlint}")
+    implementation("com.pinterest.ktlint:ktlint-reporter-plain:${Versions.ktlint}")
+    implementation("com.pinterest.ktlint:ktlint-ruleset-experimental:${Versions.ktlint}")
+    implementation("com.pinterest.ktlint:ktlint-ruleset-standard:${Versions.ktlint}")
 
     compileOnly("org.jetbrains.kotlin:kotlin-gradle-plugin")
-    compileOnly("com.android.tools.build:gradle:3.5.3")
+    compileOnly("com.android.tools.build:gradle:${Versions.androidTools}")
 
-    testImplementation("junit:junit:4.13")
-    testImplementation("com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0")
-    testImplementation("org.jetbrains:annotations:18.0.0")
+    testImplementation("junit:junit:${Versions.junit}")
+    testImplementation("com.nhaarman.mockitokotlin2:mockito-kotlin:${Versions.mockitoKotlin}")
+    testImplementation("org.jetbrains:annotations:${Versions.jetbrainsAnnotations}")
 }
 
 // Required to put the Kotlin plugin on the classpath for the functional test suite

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,8 @@
+plugins {
+    `kotlin-dsl`
+}
+
+// kotlinDslPluginOptions.experimentalWarning.set(false)
+repositories {
+    jcenter()
+}

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -2,7 +2,8 @@ plugins {
     `kotlin-dsl`
 }
 
-// kotlinDslPluginOptions.experimentalWarning.set(false)
+kotlinDslPluginOptions.experimentalWarning.set(false)
+
 repositories {
     jcenter()
 }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,0 +1,10 @@
+object Versions {
+    const val androidTools = "3.5.3"
+    const val jetbrainsAnnotations = "18.0.0"
+    const val junit = "4.13"
+    const val kotlin = "1.3.61"
+    const val kotlinter = "2.1.3"
+    const val ktlint = "0.36.0"
+    const val mockitoKotlin = "2.2.0"
+    const val pluginPublish = "0.10.1"
+}

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -2,7 +2,7 @@ object Versions {
     const val androidTools = "3.5.3"
     const val jetbrainsAnnotations = "18.0.0"
     const val junit = "4.13"
-    const val kotlin = "1.3.61"
+    const val kotlin = "1.3.60"
     const val kotlinter = "2.1.3"
     const val ktlint = "0.36.0"
     const val mockitoKotlin = "2.2.0"

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,0 @@
-rootProject.name = 'kotlinter-gradle'

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "kotlinter-gradle"


### PR DESCRIPTION
This should be applied after #124 has been merged. These changes are applied
following the same versions that were used in that merge.

This PR also uses the kotlin dsl buildSrc object to store all the versions for
all the tooling.