### PR TITLE
Fix #132 by respecting indent_size from .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,4 @@
 [*.{kt,kts}]
 max_line_length = 140
 indent_size = 4
-continuation_indent_size = 4
 insert_final_newline = true

--- a/README.md
+++ b/README.md
@@ -121,7 +121,6 @@ Options are configured in the `kotlinter` extension. Defaults shown (you may omi
 kotlinter {
     ignoreFailures = false
     indentSize = 4
-    continuationIndentSize = 4
     reporters = arrayOf("checkstyle", "plain")
     experimentalRules = false
     disabledRules = emptyArray<String>()
@@ -138,7 +137,6 @@ kotlinter {
 kotlinter {
     ignoreFailures = false
     indentSize = 4
-    continuationIndentSize = 4
     reporters = ['checkstyle', 'plain']
     experimentalRules = false
     disabledRules = []
@@ -243,14 +241,12 @@ task ktLint(type: LintTask, group: 'verification') {
             'plain': file('build/lint-report.txt'),
             'json': file('build/lint-report.json')
     ]
-    continuationIndentSize = 8
     disabledRules = ["import-ordering"]
 }
 
 task ktFormat(type: FormatTask, group: 'formatting') {
     source files('src')
     report = file('build/format-report.txt')
-    continuationIndentSize = 8
     disabledRules = ["import-ordering"]
 }
 ```

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterExtension.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterExtension.kt
@@ -5,8 +5,6 @@ import org.jmailen.gradle.kotlinter.support.ReporterType
 open class KotlinterExtension {
     companion object {
         const val DEFAULT_IGNORE_FAILURES = false
-        const val DEFAULT_INDENT_SIZE = 4
-        const val DEFAULT_CONTINUATION_INDENT_SIZE = 4
         val DEFAULT_REPORTER = ReporterType.checkstyle.name
         const val DEFAULT_EXPERIMENTAL_RULES = false
         val DEFAULT_DISABLED_RULES = emptyArray<String>()
@@ -16,9 +14,7 @@ open class KotlinterExtension {
     /** Don't fail build on lint issues */
     var ignoreFailures = DEFAULT_IGNORE_FAILURES
 
-    var indentSize = DEFAULT_INDENT_SIZE
-
-    var continuationIndentSize = DEFAULT_CONTINUATION_INDENT_SIZE
+    var indentSize: Int? = null
 
     var reporters = arrayOf(DEFAULT_REPORTER)
 

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterExtension.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterExtension.kt
@@ -16,6 +16,9 @@ open class KotlinterExtension {
 
     var indentSize: Int? = null
 
+    @Deprecated("Scheduled to be removed in 3.0.0")
+    var continuationIndentSize: Int? = null
+
     var reporters = arrayOf(DEFAULT_REPORTER)
 
     var experimentalRules = DEFAULT_EXPERIMENTAL_RULES

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterPlugin.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterPlugin.kt
@@ -45,7 +45,6 @@ class KotlinterPlugin : Plugin<Project> {
                             }
                         )
                         lintTask.indentSize.set(provider { kotlinterExtension.indentSize })
-                        lintTask.continuationIndentSize.set(provider { kotlinterExtension.continuationIndentSize })
                         lintTask.experimentalRules.set(provider { kotlinterExtension.experimentalRules })
                         lintTask.disabledRules.set(provider { kotlinterExtension.disabledRules.toList() })
                         lintTask.editorConfigPath.set(editorConfigFile())
@@ -59,7 +58,6 @@ class KotlinterPlugin : Plugin<Project> {
                         formatTask.source(resolveSources)
                         formatTask.report.set(reportFile("$id-format.txt"))
                         formatTask.indentSize.set(provider { kotlinterExtension.indentSize })
-                        formatTask.continuationIndentSize.set(provider { kotlinterExtension.continuationIndentSize })
                         formatTask.experimentalRules.set(provider { kotlinterExtension.experimentalRules })
                         formatTask.disabledRules.set(provider { kotlinterExtension.disabledRules.toList() })
                         formatTask.editorConfigPath.set(editorConfigFile())

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterPlugin.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterPlugin.kt
@@ -25,6 +25,11 @@ class KotlinterPlugin : Plugin<Project> {
 
     override fun apply(project: Project) = with(project) {
         val kotlinterExtension = extensions.create("kotlinter", KotlinterExtension::class.java)
+        afterEvaluate {
+            if (kotlinterExtension.continuationIndentSize != null) {
+                logger.warn("`continuationIndentSize` does not have any effect and will be removed in 3.0.0")
+            }
+        }
 
         // for known kotlin plugins, register tasks by convention.
         extendablePlugins.forEach { (pluginId, sourceResolver) ->

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/support/KtLintParams.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/support/KtLintParams.kt
@@ -3,8 +3,7 @@ package org.jmailen.gradle.kotlinter.support
 import java.io.Serializable
 
 data class KtLintParams(
-    val indentSize: Int,
-    val continuationIndentSize: Int,
+    val indentSize: Int?,
     val experimentalRules: Boolean,
     val disabledRules: List<String>,
     val editorConfigPath: String?

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/support/KtLintUserData.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/support/KtLintUserData.kt
@@ -1,10 +1,11 @@
 package org.jmailen.gradle.kotlinter.support
 
 fun userData(ktLintParams: KtLintParams): Map<String, String> {
-    val userData = mutableMapOf(
-        "indent_size" to ktLintParams.indentSize.toString(),
-        "continuation_indent_size" to ktLintParams.continuationIndentSize.toString()
-    )
+    val userData = mutableMapOf<String, String>()
+
+    ktLintParams.indentSize?.let { indentSize ->
+        userData["indent_size"] = indentSize.toString()
+    }
     ktLintParams.disabledRules.takeIf { it.isNotEmpty() }?.let { rules ->
         userData["disabled_rules"] = rules.joinToString(",")
     }

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/ConfigurableKtLintTask.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/ConfigurableKtLintTask.kt
@@ -9,11 +9,9 @@ import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.SourceTask
-import org.jmailen.gradle.kotlinter.KotlinterExtension.Companion.DEFAULT_CONTINUATION_INDENT_SIZE
 import org.jmailen.gradle.kotlinter.KotlinterExtension.Companion.DEFAULT_DISABLED_RULES
 import org.jmailen.gradle.kotlinter.KotlinterExtension.Companion.DEFAULT_EXPERIMENTAL_RULES
 import org.jmailen.gradle.kotlinter.KotlinterExtension.Companion.DEFAULT_FILE_BATCH_SIZE
-import org.jmailen.gradle.kotlinter.KotlinterExtension.Companion.DEFAULT_INDENT_SIZE
 import org.jmailen.gradle.kotlinter.support.KtLintParams
 
 abstract class ConfigurableKtLintTask : SourceTask() {
@@ -22,9 +20,8 @@ abstract class ConfigurableKtLintTask : SourceTask() {
     val fileBatchSize = property(default = DEFAULT_FILE_BATCH_SIZE)
 
     @Input
-    val indentSize = property(default = DEFAULT_INDENT_SIZE)
-    @Input
-    val continuationIndentSize = property(default = DEFAULT_CONTINUATION_INDENT_SIZE)
+    @Optional
+    val indentSize = property<Int?>(default = null)
     @Input
     val experimentalRules = property(default = DEFAULT_EXPERIMENTAL_RULES)
     @Input
@@ -36,8 +33,7 @@ abstract class ConfigurableKtLintTask : SourceTask() {
 
     @Internal
     protected fun getKtLintParams() = KtLintParams(
-        indentSize = indentSize.get(),
-        continuationIndentSize = continuationIndentSize.get(),
+        indentSize = indentSize.orNull,
         experimentalRules = experimentalRules.get(),
         disabledRules = disabledRules.get(),
         editorConfigPath = editorConfigPath.asFile.orNull?.path

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/ConfigurableKtLintTask.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/ConfigurableKtLintTask.kt
@@ -22,6 +22,14 @@ abstract class ConfigurableKtLintTask : SourceTask() {
     @Input
     @Optional
     val indentSize = property<Int?>(default = null)
+
+    @Internal
+    @Deprecated("Scheduled to be removed in 3.0.0")
+    var continuationIndentSize: Int? = null
+        set(value) {
+            field = value
+            logger.warn("`continuationIndentSize` does not have any effect and will be removed in 3.0.0")
+        }
     @Input
     val experimentalRules = property(default = DEFAULT_EXPERIMENTAL_RULES)
     @Input

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/CustomTaskTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/CustomTaskTest.kt
@@ -62,7 +62,6 @@ class CustomTaskTest : WithGradleTest.Kotlin() {
                     source files('src')
                     reports = ['plain': file('build/lint-report.txt')]
                     indentSize = 5
-                    continuationIndentSize = 7
                     experimentalRules = true
                     disabledRules = ["final-newline"]
                     editorConfigPath = project.rootProject.file(".editorconfig")
@@ -111,7 +110,6 @@ class CustomTaskTest : WithGradleTest.Kotlin() {
                     source files('src')
                     reports = ['plain': file('build/lint-report.txt')]
                     indentSize = 123
-                    continuationIndentSize = 17
                     experimentalRules = true
                     disabledRules = ["final-newline"]
                     editorConfigPath = project.rootProject.file(".editorconfig")
@@ -141,7 +139,6 @@ class CustomTaskTest : WithGradleTest.Kotlin() {
                 task customizedFormatTask(type: FormatTask) {
                     source files('src')
                     indentSize = 123
-                    continuationIndentSize = 17
                     experimentalRules = true
                     disabledRules = ["final-newline"]
                     editorConfigPath = project.rootProject.file(".editorconfig")

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/EditorConfigTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/EditorConfigTest.kt
@@ -1,0 +1,93 @@
+package org.jmailen.gradle.kotlinter.functional
+
+import groovy.util.GroovyTestCase.assertEquals
+import java.io.File
+import org.gradle.testkit.runner.TaskOutcome
+import org.intellij.lang.annotations.Language
+import org.jmailen.gradle.kotlinter.functional.utils.kotlinClass
+import org.jmailen.gradle.kotlinter.functional.utils.resolve
+import org.jmailen.gradle.kotlinter.functional.utils.settingsFile
+import org.junit.Before
+import org.junit.Test
+
+internal class EditorConfigTest : WithGradleTest.Kotlin() {
+
+    lateinit var projectRoot: File
+
+    @Before
+    fun setUp() {
+        projectRoot = testProjectDir.root.apply {
+            resolve("settings.gradle") { writeText(settingsFile) }
+            resolve("build.gradle") {
+                @Language("groovy")
+                val buildScript = """
+                plugins {
+                    id 'kotlin'
+                    id 'org.jmailen.kotlinter'
+                }
+                
+            """.trimIndent()
+                writeText(buildScript)
+            }
+        }
+    }
+
+    @Test
+    fun `lintTask uses default indentation if editorconfig absent`() {
+        projectRoot.resolve("src/main/kotlin/FourSpacesByDefault.kt") {
+            writeText(
+                """ |
+                    |    object FourSpacesByDefault
+                    |        
+                """.trimMargin()
+            )
+        }
+
+        build("lintKotlin").apply {
+            assertEquals(TaskOutcome.SUCCESS, task(":lintKotlinMain")?.outcome)
+        }
+    }
+
+    @Test
+    fun `plugin respects indentSize set in editorconfig`() {
+        projectRoot.resolve(".editorconfig") {
+            appendText(
+                """
+                    [*.{kt,kts}]
+                    indent_size = 2
+                """.trimIndent()
+            )
+        }
+        projectRoot.resolve("src/main/kotlin/TwoSpaces.kt") {
+            writeText(
+                """ |
+                    |  object TwoSpaces
+                    |        
+                """.trimMargin()
+            )
+        }
+
+        build("lintKotlin").apply {
+            assertEquals(TaskOutcome.SUCCESS, task(":lintKotlinMain")?.outcome)
+        }
+    }
+
+    @Test
+    fun `plugin respects disabled_rules set in editorconfig`() {
+        projectRoot.resolve(".editorconfig") {
+            appendText(
+                """
+                    [*.{kt,kts}]
+                    disabled_rules=filename
+                """.trimIndent()
+            )
+        }
+        projectRoot.resolve("src/main/kotlin/FileName.kt") {
+            writeText(kotlinClass("DifferentClassName"))
+        }
+
+        build("lintKotlin").apply {
+            assertEquals(TaskOutcome.SUCCESS, task(":lintKotlinMain")?.outcome)
+        }
+    }
+}

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/EditorConfigTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/EditorConfigTest.kt
@@ -93,21 +93,23 @@ internal class EditorConfigTest : WithGradleTest.Kotlin() {
     }
 
     @Test
-    fun `plugin extension proprties take precedence over editorconfig values`() {
+    fun `plugin extension properties take precedence over editorconfig values`() {
         projectRoot.resolve(".editorconfig") {
             appendText(
                 """
                     [*.{kt,kts}]
                     disabled_rules=filename
+                    indent_size = 2
                 """.trimIndent()
             )
         }
         projectRoot.resolve("build.gradle") {
             appendText(
                 """
-                kotlinter {
-                    disabledRules = ['paren-spacing']
-                }
+                    kotlinter {
+                        disabledRules = ['paren-spacing']  
+                        indentSize = 6
+                    }
                 
                 """.trimIndent()
             )
@@ -117,7 +119,7 @@ internal class EditorConfigTest : WithGradleTest.Kotlin() {
             val content = """
                 class WrongFileName {
 
-                    fun unnecessarySpace () = 2
+                  fun unnecessarySpace () = 2
                 }
 
                 """.trimIndent()
@@ -128,6 +130,7 @@ internal class EditorConfigTest : WithGradleTest.Kotlin() {
         buildAndFail("lintKotlin").apply {
             assertEquals(TaskOutcome.FAILED, task(":lintKotlinMain")?.outcome)
             assertTrue(output.contains("[filename] class WrongFileName should be declared in a file named WrongFileName.kt"))
+            assertTrue(output.contains("[indent] Unexpected indentation (2) (it should be 6)"))
         }
     }
 }

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/ExtensionTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/ExtensionTest.kt
@@ -181,4 +181,22 @@ internal class ExtensionTest : WithGradleTest.Kotlin() {
             assertTrue(output.contains("[filename] class Precedence should be declared in a file named Precedence.kt"))
         }
     }
+
+    @Test
+    fun `shows deprecation warning for continuationIndentSize property`() {
+        projectRoot.resolve("build.gradle") {
+            @Language("groovy")
+            val script = """
+                kotlinter {
+                    continuationIndentSize = 100
+                }
+                
+            """.trimIndent()
+            appendText(script)
+        }
+
+        build("lintKotlin").apply {
+            assertTrue(output.contains("`continuationIndentSize` does not have any effect"))
+        }
+    }
 }


### PR DESCRIPTION
Fixes #132 

The reson why properties set in `.editorconfig` weren't respected is that we were always passing them in ktlint's userData which are higher in hierarchy than those set in `.editorconfig`.

In addition I removed support for `continuation_indent_size` as it is no longer recognized by ktlint https://github.com/pinterest/ktlint/issues/171 (I could mark it as deprecated though 🤔WDYT?)