### PR TITLE
Temporarily disable pre-commit hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,7 @@ Granular tasks exist for each source set in the project: `formatKotlin`*`SourceS
 
 ### Git Hooks
 
-Kotlinter can install hooks to run pre-push (`installKotlinterPrePushHook`) or pre-commit
-(`installKotlinterPreCommitHook`).  The hook runs `lintKotlin` and, if there are errors, `formatKotlin` and exits
+Kotlinter can install a hook to run pre-push (`installKotlinterPrePushHook`). The hook runs `lintKotlin` and, if there are errors, `formatKotlin` and exits
 non-zero leaving changed files to be committed.
 
 ### Configuration

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterPlugin.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterPlugin.kt
@@ -4,6 +4,7 @@ import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.api.AndroidSourceSet
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.file.ConfigurableFileTree
 import org.gradle.api.file.FileTree
 import org.gradle.api.file.SourceDirectorySet
 import org.gradle.api.internal.HasConvention
@@ -42,7 +43,6 @@ class KotlinterPlugin : Plugin<Project> {
 
                 if (project.rootProject == project) {
                     registerPrePushHookTask()
-                    registerPreCommitHookTask()
                 }
 
                 sourceResolver.applyToAll(project) { id, resolveSources ->
@@ -150,7 +150,7 @@ internal object AndroidSourceSetResolver : SourceSetResolver {
 
     private fun getKotlinFiles(project: Project, sourceSet: AndroidSourceSet) = sourceSet.java.srcDirs.map { dir ->
         project.fileTree(dir) { it.include("**/*.kt") }
-    }.reduce { merged: FileTree, tree ->
+    }.reduce { merged: FileTree, tree: ConfigurableFileTree ->
         merged + tree
     }
 }

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/GitHookTasks.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/GitHookTasks.kt
@@ -124,8 +124,8 @@ abstract class InstallHookTask(private val hookFile: String) : DefaultTask() {
                 """
                 |$startHook
                 |GRADLEW=$gradlew
-                |$hookContent\n
-                """.trimMargin() +
-                (if (includeEndHook) endHook else "")
+                |$hookContent
+                |${if (includeEndHook) endHook else ""}
+                """.trimMargin()
     }
 }

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/InstallHookTaskTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/InstallHookTaskTest.kt
@@ -140,5 +140,4 @@ abstract class InstallHookTaskTest(
     }
 }
 
-class InstallPreCommitHookTaskTest : InstallHookTaskTest("installKotlinterPreCommitHook", "pre-commit")
 class InstallPrePushHookTaskTest : InstallHookTaskTest("installKotlinterPrePushHook", "pre-push")


### PR DESCRIPTION
To be helpful for automatically formatting, it would need to add the changes to the commi, which isn't a style of format command we have yet.