### PR TITLE
Release 3.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Available on the Gradle Plugins Portal: https://plugins.gradle.org/plugin/org.jm
 
 ```kotlin
 plugins {
-    id("org.jmailen.kotlinter") version "3.3.0"
+    id("org.jmailen.kotlinter") version "3.4.0"
 }
 ```
 
@@ -30,7 +30,7 @@ plugins {
 
 ```groovy
 plugins {
-    id "org.jmailen.kotlinter" version "3.3.0"
+    id "org.jmailen.kotlinter" version "3.4.0"
 }
 ```
 
@@ -50,7 +50,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath("org.jmailen.gradle:kotlinter-gradle:3.3.0")
+        classpath("org.jmailen.gradle:kotlinter-gradle:3.4.0")
     }
 }
 ```
@@ -75,7 +75,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath "org.jmailen.gradle:kotlinter-gradle:3.3.0"
+        classpath "org.jmailen.gradle:kotlinter-gradle:3.4.0"
     }
 }
 ```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,8 +10,9 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
     google()
+    jcenter() // remove after trove4j resolved https://youtrack.jetbrains.com/issue/KT-44730
 }
 
 val pluginId = "org.jmailen.kotlinter"
@@ -19,7 +20,7 @@ val githubUrl ="https://github.com/jeremymailen/kotlinter-gradle"
 val webUrl = "https://github.com/jeremymailen/kotlinter-gradle"
 val projectDescription = "Lint and formatting for Kotlin using ktlint with configuration-free setup on JVM and Android projects"
 
-version = "3.3.0"
+version = "3.4.0"
 group = "org.jmailen.gradle"
 description = projectDescription
 


### PR DESCRIPTION
Switch to maven central for dependencies for #173. Jcenter there as vestigal because one last dependency (trove4j) needs moving.