### PR TITLE
Fix hook install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ tasks.check {
 <summary>Groovy</summary>
 
 ```groovy
-task check {
+check {
     dependsOn "installKotlinterPrePushHook"
 }
 ```


### PR DESCRIPTION
As to configure existing check task instead of trying to create a new one.