### PR TITLE
Simplify gradle config

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,21 +65,15 @@ tasks {
         dependsOn(generateVersionProperties)
     }
 
-    withType<KotlinCompile>().configureEach {
+    withType<KotlinCompile> {
         kotlinOptions {
-            apiVersion = "1.4"
-            languageVersion = "1.4"
             jvmTarget = JavaVersion.VERSION_1_8.toString()
         }
     }
 
     // Required to put the Kotlin plugin on the classpath for the functional test suite
-    withType<PluginUnderTestMetadata>().configureEach {
+    withType<PluginUnderTestMetadata> {
         pluginClasspath.from(configurations.compileOnly)
-    }
-
-    wrapper {
-        gradleVersion = "7.0"
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ repositories {
 }
 
 val pluginId = "org.jmailen.kotlinter"
-val githubUrl ="https://github.com/jeremymailen/kotlinter-gradle"
+val githubUrl = "https://github.com/jeremymailen/kotlinter-gradle"
 val webUrl = "https://github.com/jeremymailen/kotlinter-gradle"
 val projectDescription = "Lint and formatting for Kotlin using ktlint with configuration-free setup on JVM and Android projects"
 
@@ -65,14 +65,14 @@ tasks {
         dependsOn(generateVersionProperties)
     }
 
-    withType<KotlinCompile> {
+    withType<KotlinCompile>().configureEach {
         kotlinOptions {
             jvmTarget = JavaVersion.VERSION_1_8.toString()
         }
     }
 
     // Required to put the Kotlin plugin on the classpath for the functional test suite
-    withType<PluginUnderTestMetadata> {
+    withType<PluginUnderTestMetadata>().configureEach {
         pluginClasspath.from(configurations.compileOnly)
     }
 }
@@ -121,7 +121,7 @@ artifacts {
 }
 
 publishing {
-    publications.withType<MavenPublication> {
+    publications.withType<MavenPublication>().configureEach {
         artifact(sourcesJar.get())
 
         pom {


### PR DESCRIPTION
- Use extension method to simplify `withType`
- `apiVersion` & `languageVersion` need not be declared, they will follow the kotlin plugin' version by default.
- `wrapper` can be removed also as below.

![image](https://user-images.githubusercontent.com/10363352/114890290-76e75d80-9e3d-11eb-96e3-7e3897022745.png)
