### PR TITLE
Specify toolchain to ensure Java 11+ compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Available on the Gradle Plugins Portal: https://plugins.gradle.org/plugin/org.jm
 
 ```kotlin
 plugins {
-    id("org.jmailen.kotlinter") version "3.4.1"
+    id("org.jmailen.kotlinter") version "3.4.2"
 }
 ```
 
@@ -30,7 +30,7 @@ plugins {
 
 ```groovy
 plugins {
-    id "org.jmailen.kotlinter" version "3.4.1"
+    id "org.jmailen.kotlinter" version "3.4.2"
 }
 ```
 
@@ -50,7 +50,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath("org.jmailen.gradle:kotlinter-gradle:3.4.1")
+        classpath("org.jmailen.gradle:kotlinter-gradle:3.4.2")
     }
 }
 ```
@@ -75,7 +75,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath "org.jmailen.gradle:kotlinter-gradle:3.4.1"
+        classpath "org.jmailen.gradle:kotlinter-gradle:3.4.2"
     }
 }
 ```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,7 @@ val githubUrl ="https://github.com/jeremymailen/kotlinter-gradle"
 val webUrl = "https://github.com/jeremymailen/kotlinter-gradle"
 val projectDescription = "Lint and formatting for Kotlin using ktlint with configuration-free setup on JVM and Android projects"
 
-version = "3.4.1"
+version = "3.4.2"
 group = "org.jmailen.gradle"
 description = projectDescription
 
@@ -52,6 +52,12 @@ dependencies {
     testImplementation("org.jetbrains:annotations:${Versions.jetbrainsAnnotations}")
 }
 
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(11))
+    }
+}
+
 tasks {
     val generateVersionProperties = create("generateVersionProperties") {
         doLast {
@@ -68,7 +74,7 @@ tasks {
         kotlinOptions {
             apiVersion = "1.4"
             languageVersion = "1.4"
-            jvmTarget = JavaVersion.VERSION_1_8.toString()
+            jvmTarget = JavaVersion.VERSION_11.toString()
         }
     }
 


### PR DESCRIPTION
It was built before in such a way it was requiring JDK 15.
Went ahead and bumped the bytecode version up as well to Java 11, 1.8 is pretty old and unsupported now.

Fixes #189 