### PR TITLE
Bump Gradle to 7.0.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -84,7 +84,7 @@ tasks {
     }
 
     wrapper {
-        gradleVersion = "7.0"
+        gradleVersion = "7.0.2"
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Gradle has released a new version `7.0.1` which contains number of fixes: https://github.com/gradle/gradle/milestone/173?closed=1
Gradle also released a new version `7.0.2` which contains following fixes: 
https://github.com/gradle/gradle/milestone/177?closed=1

As I've been already doing stuff around the plugin I thought I can bump Gradle as well, ~but to save everyone's time in the future I also suggest to use a Github Action that will automate that process.~

~Feel free to revert the last commit if you prefer bumping things manually.~