### PR TITLE
Upgrade workflows to `gradle-build-action@v2`

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -23,21 +23,16 @@ jobs:
           distribution: 'adopt'
           java-version: 16
 
-      - name: Cache .gradle
-        uses: burrunan/gradle-cache-action@v1
-        with:
-          gradle-distribution-sha-256-sum-warning: false
-
       - name: Gradle wrapper validation
         uses: gradle/wrapper-validation-action@v1
 
       - name: ./gradlew assemble
-        uses: gradle/gradle-build-action@v1
+        uses: gradle/gradle-build-action@v2
         with:
           arguments: assemble
 
       - name: ./gradlew check
-        uses: gradle/gradle-build-action@v1
+        uses: gradle/gradle-build-action@v2
         with:
           arguments: check
 
@@ -68,7 +63,7 @@ jobs:
           distribution: 'adopt'
           java-version: ${{ matrix.java }}
 
-      - uses: gradle/gradle-build-action@v1
+      - uses: gradle/gradle-build-action@v2
         with:
           build-root-directory: test-project
           gradle-version: ${{ matrix.gradle }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         uses: gradle/wrapper-validation-action@v1
 
       - name: ./gradlew publishPlugins
-        uses: gradle/gradle-build-action@v1
+        uses: gradle/gradle-build-action@v2
         env:
           GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
           GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}


### PR DESCRIPTION
Upgrades the GitHub actions workflows to the latest v2 version (presently v2.0-beta.7).

This new action:
- has simpler configuration
- does a better job of caching the Gradle User Home state between build invocations
- automatically adds annotations with build scan URLs for all gradle invocations.

Due to the second item, I've removed the separate use of `burrunan/gradle-cache-action` for caching.
I'd be very interested to know if there is any regression in performance with this change.