### PR TITLE
Fix `src/main/kotlin` not being recognised by default

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -50,7 +50,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest, windows-latest ]
         gradle: [ 7.0.1, current, rc ]
-        java: [ 8, 11, 16 ]
+        java: [ 8, 11, 17 ]
     name: '[${{ matrix.os }}] Gradle: ${{ matrix.gradle }}, Java: ${{ matrix.java }}'
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -49,7 +49,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest ]
-        gradle: [ 7.0.1, current, rc ]
+        gradle: [ 7.0.1, current, release-candidate ]
         java: [ 8, 11, 17 ]
         exclude:
           - os: ubuntu-latest
@@ -76,3 +76,37 @@ jobs:
           build-root-directory: test-project
           gradle-version: ${{ matrix.gradle }}
           arguments: formatKotlin lintKotlin
+
+  integration-tests-android:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        gradle: [ current ]
+        java: [ 17 ]
+        agp: [ 7.0.4 ]
+        include:
+          - gradle: 7.0.1
+            java: 11
+            agp: 4.2.2
+          - gradle: 6.9.1
+            java: 8
+            agp: 4.0.0
+
+    name: '[android] Gradle: ${{ matrix.gradle }}, Java: ${{ matrix.java }}, AGP: ${{ matrix.agp }}'
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: ${{ matrix.java }}
+
+      - uses: gradle/gradle-build-action@v2
+        with:
+          build-root-directory: test-project
+          gradle-version: ${{ matrix.gradle }}
+          arguments: formatKotlin lintKotlin -PagpVersion=${{ matrix.agp }}

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -107,6 +107,6 @@ jobs:
 
       - uses: gradle/gradle-build-action@v2
         with:
-          build-root-directory: test-project
+          build-root-directory: test-project-android
           gradle-version: ${{ matrix.gradle }}
           arguments: formatKotlin lintKotlin -PagpVersion=${{ matrix.agp }}

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -51,6 +51,14 @@ jobs:
         os: [ ubuntu-latest, windows-latest ]
         gradle: [ 7.0.1, current, rc ]
         java: [ 8, 11, 17 ]
+        exclude:
+          - os: ubuntu-latest
+            gradle: 7.0.1
+            java: 17
+          - os: windows-latest
+            gradle: 7.0.1
+            java: 17
+
     name: '[${{ matrix.os }}] Gradle: ${{ matrix.gradle }}, Java: ${{ matrix.java }}'
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: 'adopt'
-          java-version: 16
+          java-version: 17
 
       - name: Gradle wrapper validation
         uses: gradle/wrapper-validation-action@v1

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -83,7 +83,7 @@ tasks {
     }
 
     wrapper {
-        gradleVersion = "7.3.1"
+        gradleVersion = "7.3.2"
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -85,7 +85,7 @@ tasks {
     }
 
     wrapper {
-        gradleVersion = "7.2"
+        gradleVersion = "7.3.1"
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,8 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    kotlin("jvm") version "1.5.31"
-    id("com.gradle.plugin-publish") version "0.15.0"
+    kotlin("jvm") version "1.6.10"
+    id("com.gradle.plugin-publish") version "0.18.0"
     `java-gradle-plugin`
     `maven-publish`
     id("org.jmailen.kotlinter") version "3.6.0"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,6 @@ description = projectDescription
 
 object Versions {
     const val androidTools = "4.2.2"
-    const val jetbrainsAnnotations = "22.0.0"
     const val junit = "4.13.2"
     const val ktlint = "0.43.0"
     const val mockitoKotlin = "4.0.0"
@@ -50,7 +49,6 @@ dependencies {
 
     testImplementation("junit:junit:${Versions.junit}")
     testImplementation("org.mockito.kotlin:mockito-kotlin:${Versions.mockitoKotlin}")
-    testImplementation("org.jetbrains:annotations:${Versions.jetbrainsAnnotations}")
 }
 
 java {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/pluginapplier/AndroidSourceSetApplier.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/pluginapplier/AndroidSourceSetApplier.kt
@@ -23,7 +23,9 @@ internal object AndroidSourceSetApplier : SourceSetApplier {
 
     private fun getKotlinFiles(project: Project, sourceSet: AndroidSourceSet): FileTree? {
         val javaSources = sourceSet.java.srcDirs
-        val kotlinSources = (sourceSet.kotlin as? com.android.build.gradle.api.AndroidSourceDirectorySet)?.srcDirs.orEmpty()
+        val kotlinSources = runCatching { (sourceSet.kotlin as? com.android.build.gradle.api.AndroidSourceDirectorySet)?.srcDirs }
+            .getOrNull()
+            .orEmpty()
 
         return (javaSources + kotlinSources)
             .map { dir -> project.fileTree(dir) { it.include("**/*.kt") } }

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/pluginapplier/AndroidSourceSetApplier.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/pluginapplier/AndroidSourceSetApplier.kt
@@ -23,6 +23,7 @@ internal object AndroidSourceSetApplier : SourceSetApplier {
 
     private fun getKotlinFiles(project: Project, sourceSet: AndroidSourceSet): FileTree? {
         val javaSources = sourceSet.java.srcDirs
+        // detect Kotlin source paths supported by AGP 7 and later
         val kotlinSources = runCatching { (sourceSet.kotlin as? com.android.build.gradle.api.AndroidSourceDirectorySet)?.srcDirs }
             .getOrNull()
             .orEmpty()

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/pluginapplier/AndroidSourceSetApplier.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/pluginapplier/AndroidSourceSetApplier.kt
@@ -14,18 +14,19 @@ import org.jmailen.gradle.kotlinter.id
 internal object AndroidSourceSetApplier : SourceSetApplier {
 
     override fun applyToAll(project: Project, action: SourceSetAction) {
-        val android = project.extensions.findByName("android")
-        (android as? BaseExtension)?.let {
-            it.sourceSets.all { sourceSet ->
-                val id = sourceSet.name.id
-                action(id, project.provider { getKotlinFiles(project, sourceSet) })
-            }
+        val android = project.extensions.findByName("android") as? BaseExtension ?: return
+        android.sourceSets.configureEach { sourceSet ->
+            val id = sourceSet.name.id
+            action(id, project.provider { getKotlinFiles(project, sourceSet) })
         }
     }
 
-    private fun getKotlinFiles(project: Project, sourceSet: AndroidSourceSet) = sourceSet.java.srcDirs.map { dir ->
-        project.fileTree(dir) { it.include("**/*.kt") }
-    }.reduce { merged: FileTree, tree: ConfigurableFileTree ->
-        merged + tree
+    private fun getKotlinFiles(project: Project, sourceSet: AndroidSourceSet): FileTree? {
+        val javaSources = sourceSet.java.srcDirs
+        val kotlinSources = (sourceSet.kotlin as? com.android.build.gradle.api.AndroidSourceDirectorySet)?.srcDirs.orEmpty()
+
+        return (javaSources + kotlinSources)
+            .map { dir -> project.fileTree(dir) { it.include("**/*.kt") } }
+            .reduce { merged: FileTree, tree: ConfigurableFileTree -> merged + tree }
     }
 }

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/pluginapplier/KotlinJvmSourceSetApplier.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/pluginapplier/KotlinJvmSourceSetApplier.kt
@@ -11,7 +11,7 @@ import org.jmailen.gradle.kotlinter.id
 internal object KotlinJvmSourceSetApplier : SourceSetApplier {
 
     override fun applyToAll(project: Project, action: SourceSetAction) {
-        getSourceSets(project).all { sourceSet ->
+        getSourceSets(project).configureEach { sourceSet ->
             sourceSet.kotlin.let { directorySet ->
                 action(directorySet.name.id, project.provider { directorySet })
             }

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/pluginapplier/KotlinMultiplatformSourceSetApplier.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/pluginapplier/KotlinMultiplatformSourceSetApplier.kt
@@ -11,7 +11,7 @@ import org.jmailen.gradle.kotlinter.id
 object KotlinMultiplatformSourceSetApplier : SourceSetApplier {
 
     override fun applyToAll(project: Project, action: SourceSetAction) {
-        getSourceSets(project).all { sourceSet ->
+        getSourceSets(project).configureEach { sourceSet ->
             sourceSet.kotlin.let { directorySet ->
                 action(directorySet.name.id, project.provider { directorySet })
             }

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/AndroidProjectTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/AndroidProjectTest.kt
@@ -1,0 +1,101 @@
+package org.jmailen.gradle.kotlinter.functional
+
+import org.gradle.testkit.runner.TaskOutcome
+import org.jmailen.gradle.kotlinter.functional.utils.androidManifest
+import org.jmailen.gradle.kotlinter.functional.utils.kotlinClass
+import org.jmailen.gradle.kotlinter.functional.utils.resolve
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+
+internal class AndroidProjectTest : WithGradleTest.Android() {
+
+    private lateinit var androidModuleRoot: File
+
+    @Before
+    fun setUp() {
+        testProjectDir.root.apply {
+            resolve("settings.gradle") { writeText(settingsFile) }
+            resolve("build.gradle") {
+                // language=groovy
+                val buildScript =
+                    """
+                subprojects {
+                    repositories {
+                        google()
+                        mavenCentral()
+                    }
+                }
+                
+                    """.trimIndent()
+                writeText(buildScript)
+            }
+            androidModuleRoot = resolve("androidproject") {
+                resolve("build.gradle") {
+                    // language=groovy
+                    val androidBuildScript =
+                        """
+                        plugins {
+                            id 'com.android.library'
+                            id 'kotlin-android'
+                            id 'org.jmailen.kotlinter'
+                        }
+                        
+                        android {
+                            compileSdkVersion 31
+                            defaultConfig {
+                                minSdkVersion 23
+                            }
+                            
+                            flavorDimensions 'customFlavor'
+                            productFlavors {
+                                flavorOne {
+                                    dimension 'customFlavor'
+                                }
+                                flavorTwo {
+                                    dimension 'customFlavor'
+                                }
+                            }
+                        }
+                        
+                        """.trimIndent()
+                    writeText(androidBuildScript)
+                }
+                resolve("src/main/AndroidManifest.xml") {
+                    writeText(androidManifest)
+                }
+                resolve("src/main/kotlin/MainSourceSet.kt") {
+                    writeText(kotlinClass("MainSourceSet"))
+                }
+                resolve("src/debug/kotlin/DebugSourceSet.kt") {
+                    writeText(kotlinClass("DebugSourceSet"))
+                }
+                resolve("src/test/kotlin/TestSourceSet.kt") {
+                    writeText(kotlinClass("TestSourceSet"))
+                }
+                resolve("src/flavorOne/kotlin/FlavorSourceSet.kt") {
+                    writeText(kotlinClass("FlavorSourceSet"))
+                }
+            }
+        }
+    }
+
+    @Test
+    fun runsOnAndroidProject() {
+        build("lintKotlin").apply {
+            assertEquals(TaskOutcome.SUCCESS, task(":androidproject:lintKotlinMain")?.outcome)
+            assertEquals(TaskOutcome.SUCCESS, task(":androidproject:lintKotlinDebug")?.outcome)
+            assertEquals(TaskOutcome.SUCCESS, task(":androidproject:lintKotlinTest")?.outcome)
+            assertEquals(TaskOutcome.SUCCESS, task(":androidproject:lintKotlinFlavorOne")?.outcome)
+            assertEquals(TaskOutcome.SUCCESS, task(":androidproject:lintKotlin")?.outcome)
+        }
+    }
+
+    // language=groovy
+    private val settingsFile =
+        """
+        rootProject.name = 'kotlinter'
+        include 'androidproject'
+        """.trimIndent()
+}

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/CustomTaskTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/CustomTaskTest.kt
@@ -1,7 +1,6 @@
 package org.jmailen.gradle.kotlinter.functional
 
 import org.gradle.testkit.runner.TaskOutcome
-import org.intellij.lang.annotations.Language
 import org.jmailen.gradle.kotlinter.functional.utils.editorConfig
 import org.jmailen.gradle.kotlinter.functional.utils.kotlinClass
 import org.jmailen.gradle.kotlinter.functional.utils.resolve
@@ -22,7 +21,7 @@ class CustomTaskTest : WithGradleTest.Kotlin() {
         projectRoot = testProjectDir.root.apply {
             resolve("settings.gradle") { writeText(settingsFile) }
             resolve("build.gradle") {
-                @Language("groovy")
+                // language=groovy
                 val buildScript =
                     """
                     plugins {
@@ -45,7 +44,7 @@ class CustomTaskTest : WithGradleTest.Kotlin() {
             writeText(editorConfig)
         }
         projectRoot.resolve("src/main/kotlin/CustomClass.kt") {
-            @Language("kotlin")
+            // language=kotlin
             val validClass =
                 """
                 class CustomClass {
@@ -57,7 +56,7 @@ class CustomTaskTest : WithGradleTest.Kotlin() {
             writeText(validClass)
         }
         projectRoot.resolve("build.gradle") {
-            @Language("groovy")
+            // language=groovy
             val buildScript =
                 """
                 import org.jmailen.gradle.kotlinter.tasks.LintTask
@@ -82,7 +81,7 @@ class CustomTaskTest : WithGradleTest.Kotlin() {
     @Test
     fun `ktLint custom task succeeds with default configuration`() {
         projectRoot.resolve("build.gradle") {
-            @Language("groovy")
+            // language=groovy
             val buildScript =
                 """
                 import org.jmailen.gradle.kotlinter.tasks.LintTask
@@ -106,7 +105,7 @@ class CustomTaskTest : WithGradleTest.Kotlin() {
             writeText(editorConfig)
         }
         projectRoot.resolve("build.gradle") {
-            @Language("groovy")
+            // language=groovy
             val buildScript =
                 """
                 import org.jmailen.gradle.kotlinter.tasks.LintTask
@@ -135,7 +134,7 @@ class CustomTaskTest : WithGradleTest.Kotlin() {
             writeText(editorConfig)
         }
         projectRoot.resolve("build.gradle") {
-            @Language("groovy")
+            // language=groovy
             val buildScript =
                 """
                 import org.jmailen.gradle.kotlinter.tasks.FormatTask
@@ -159,7 +158,7 @@ class CustomTaskTest : WithGradleTest.Kotlin() {
     @Test
     fun `ktLint custom task skips reports generation if reports not configured`() {
         projectRoot.resolve("src/main/kotlin/MissingNewLine.kt") {
-            @Language("kotlin")
+            // language=kotlin
             val validClass =
                 """
                 class MissingNewLine
@@ -167,7 +166,7 @@ class CustomTaskTest : WithGradleTest.Kotlin() {
             writeText(validClass)
         }
         projectRoot.resolve("build.gradle") {
-            @Language("groovy")
+            // language=groovy
             val buildScript =
                 """
                 import org.jmailen.gradle.kotlinter.tasks.LintTask
@@ -200,7 +199,7 @@ class CustomTaskTest : WithGradleTest.Kotlin() {
     @Test
     fun `ktLint custom task became up-to-date on second run if reports not configured`() {
         projectRoot.resolve("build.gradle") {
-            @Language("groovy")
+            // language=groovy
             val buildScript =
                 """
                 import org.jmailen.gradle.kotlinter.tasks.LintTask
@@ -235,7 +234,7 @@ class CustomTaskTest : WithGradleTest.Kotlin() {
     @Test
     fun `ktLint custom task treats reports as input parameter`() {
         projectRoot.resolve("build.gradle") {
-            @Language("groovy")
+            // language=groovy
             val buildScript =
                 """
                 import org.jmailen.gradle.kotlinter.tasks.LintTask

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/EditorConfigTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/EditorConfigTest.kt
@@ -1,7 +1,6 @@
 package org.jmailen.gradle.kotlinter.functional
 
 import org.gradle.testkit.runner.TaskOutcome
-import org.intellij.lang.annotations.Language
 import org.jmailen.gradle.kotlinter.functional.utils.kotlinClass
 import org.jmailen.gradle.kotlinter.functional.utils.resolve
 import org.jmailen.gradle.kotlinter.functional.utils.settingsFile
@@ -20,7 +19,7 @@ internal class EditorConfigTest : WithGradleTest.Kotlin() {
         projectRoot = testProjectDir.root.apply {
             resolve("settings.gradle") { writeText(settingsFile) }
             resolve("build.gradle") {
-                @Language("groovy")
+                // language=groovy
                 val buildScript =
                     """
                 plugins {
@@ -120,7 +119,7 @@ internal class EditorConfigTest : WithGradleTest.Kotlin() {
             )
         }
         projectRoot.resolve("src/main/kotlin/FileName.kt") {
-            @Language("kotlin")
+            // language=kotlin
             val content =
                 """
                 class WrongFileName {

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/ExtensionTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/ExtensionTest.kt
@@ -1,7 +1,6 @@
 package org.jmailen.gradle.kotlinter.functional
 
 import org.gradle.testkit.runner.TaskOutcome
-import org.intellij.lang.annotations.Language
 import org.jmailen.gradle.kotlinter.functional.utils.kotlinClass
 import org.jmailen.gradle.kotlinter.functional.utils.resolve
 import org.jmailen.gradle.kotlinter.functional.utils.settingsFile
@@ -20,7 +19,7 @@ internal class ExtensionTest : WithGradleTest.Kotlin() {
         projectRoot = testProjectDir.root.apply {
             resolve("settings.gradle") { writeText(settingsFile) }
             resolve("build.gradle") {
-                @Language("groovy")
+                // language=groovy
                 val buildScript =
                     """
                 plugins {
@@ -37,7 +36,7 @@ internal class ExtensionTest : WithGradleTest.Kotlin() {
     @Test
     fun `extension configures ignoreFailures`() {
         projectRoot.resolve("build.gradle") {
-            @Language("groovy")
+            // language=groovy
             val script =
                 """
                 kotlinter {
@@ -58,7 +57,7 @@ internal class ExtensionTest : WithGradleTest.Kotlin() {
     @Test
     fun `extension configures indentSize`() {
         projectRoot.resolve("build.gradle") {
-            @Language("groovy")
+            // language=groovy
             val script =
                 """
                 kotlinter {
@@ -86,7 +85,7 @@ internal class ExtensionTest : WithGradleTest.Kotlin() {
     @Test
     fun `extension configures reporters`() {
         projectRoot.resolve("build.gradle") {
-            @Language("groovy")
+            // language=groovy
             val script =
                 """
                 kotlinter {
@@ -109,7 +108,7 @@ internal class ExtensionTest : WithGradleTest.Kotlin() {
     @Test
     fun `extension configures disabledRules`() {
         projectRoot.resolve("build.gradle") {
-            @Language("groovy")
+            // language=groovy
             val script =
                 """
                 kotlinter {
@@ -130,7 +129,7 @@ internal class ExtensionTest : WithGradleTest.Kotlin() {
     @Test
     fun `extension properties are evaluated only during task execution`() {
         projectRoot.resolve("build.gradle") {
-            @Language("groovy")
+            // language=groovy
             val buildScript =
                 """
                 plugins {
@@ -161,7 +160,7 @@ internal class ExtensionTest : WithGradleTest.Kotlin() {
     @Test
     fun `user customized values take precedence over extension values`() {
         projectRoot.resolve("src/main/kotlin/FileName.kt") {
-            @Language("kotlin")
+            // language=kotlin
             val kotlinClass =
                 """
                 class Precedence {
@@ -171,7 +170,7 @@ internal class ExtensionTest : WithGradleTest.Kotlin() {
             writeText(kotlinClass)
         }
         projectRoot.resolve("build.gradle") {
-            @Language("groovy")
+            // language=groovy
             val script =
                 """
                 kotlinter {

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/KotlinProjectTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/KotlinProjectTest.kt
@@ -183,7 +183,7 @@ internal class KotlinProjectTest : WithGradleTest.Kotlin() {
         val buildscript =
             """
             plugins {
-                id 'org.jetbrains.kotlin.jvm' version '1.4.32'
+                id 'org.jetbrains.kotlin.jvm'
                 id 'org.jmailen.kotlinter'
             }
 

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/KotlinProjectTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/KotlinProjectTest.kt
@@ -3,7 +3,6 @@ package org.jmailen.gradle.kotlinter.functional
 import org.gradle.testkit.runner.TaskOutcome.FAILED
 import org.gradle.testkit.runner.TaskOutcome.SUCCESS
 import org.gradle.testkit.runner.TaskOutcome.UP_TO_DATE
-import org.intellij.lang.annotations.Language
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -78,7 +77,7 @@ internal class KotlinProjectTest : WithGradleTest.Kotlin() {
     fun `formatKotlin reports formatted and unformatted files`() {
         settingsFile()
         buildFile()
-        @Language("kotlin")
+        // language=kotlin
         val kotlinClass =
             """
             import System.*
@@ -180,7 +179,7 @@ internal class KotlinProjectTest : WithGradleTest.Kotlin() {
     }
 
     private fun buildFile() = buildFile.apply {
-        @Language("groovy")
+        // language=groovy
         val buildscript =
             """
             plugins {

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/ModifiedSourceSetsTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/ModifiedSourceSetsTest.kt
@@ -1,7 +1,6 @@
 package org.jmailen.gradle.kotlinter.functional
 
 import org.gradle.testkit.runner.TaskOutcome
-import org.intellij.lang.annotations.Language
 import org.jmailen.gradle.kotlinter.functional.utils.androidManifest
 import org.jmailen.gradle.kotlinter.functional.utils.kotlinClass
 import org.jmailen.gradle.kotlinter.functional.utils.resolve
@@ -20,7 +19,7 @@ internal class ModifiedSourceSetsTest : WithGradleTest.Android() {
         testProjectDir.root.apply {
             resolve("settings.gradle") { writeText(settingsFile) }
             resolve("build.gradle") {
-                @Language("groovy")
+                // language=groovy
                 val buildScript =
                     """
                 subprojects {
@@ -35,7 +34,7 @@ internal class ModifiedSourceSetsTest : WithGradleTest.Android() {
             }
             androidModuleRoot = resolve("androidproject") {
                 resolve("build.gradle") {
-                    @Language("groovy")
+                    // language=groovy
                     val androidBuildScript =
                         """
                         plugins {
@@ -88,7 +87,7 @@ internal class ModifiedSourceSetsTest : WithGradleTest.Android() {
             }
             kotlinModuleRoot = resolve("kotlinproject") {
                 resolve("build.gradle") {
-                    @Language("groovy")
+                    // language=groovy
                     val kotlinBuildScript =
                         """
                         plugins {
@@ -148,7 +147,7 @@ internal class ModifiedSourceSetsTest : WithGradleTest.Android() {
         }
     }
 
-    @Language("groovy")
+    // language=groovy
     private val settingsFile =
         """
         rootProject.name = 'kotlinter'

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/ModifiedSourceSetsTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/ModifiedSourceSetsTest.kt
@@ -44,7 +44,7 @@ internal class ModifiedSourceSetsTest : WithGradleTest.Android() {
                         }
                         
                         android {
-                            compileSdkVersion 29
+                            compileSdkVersion 31
                             defaultConfig {
                                 minSdkVersion 23
                             }

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/utils/Factories.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/utils/Factories.kt
@@ -1,22 +1,20 @@
 package org.jmailen.gradle.kotlinter.functional.utils
 
-import org.intellij.lang.annotations.Language
-
-@Language("kotlin")
+// language=kotlin
 internal fun kotlinClass(className: String) =
     """
     object $className
     
     """.trimIndent()
 
-@Language("groovy")
+// language=groovy
 internal val settingsFile =
     """
     rootProject.name = 'kotlinter'
     
     """.trimIndent()
 
-@Language("xml")
+// language=xml
 internal val androidManifest =
     """
      <manifest package="com.example" />

--- a/test-project-android/build.gradle.kts
+++ b/test-project-android/build.gradle.kts
@@ -1,0 +1,9 @@
+plugins {
+    kotlin("android") version "1.6.10"
+    id("com.android.library")
+    id("org.jmailen.kotlinter")
+}
+
+android {
+    compileSdk = 31
+}

--- a/test-project-android/build.gradle.kts
+++ b/test-project-android/build.gradle.kts
@@ -5,5 +5,5 @@ plugins {
 }
 
 android {
-    compileSdk = 31
+    compileSdkVersion(31)
 }

--- a/test-project-android/gradle.properties
+++ b/test-project-android/gradle.properties
@@ -1,0 +1,2 @@
+kotlin.code.style=official
+org.gradle.caching=true

--- a/test-project-android/settings.gradle.kts
+++ b/test-project-android/settings.gradle.kts
@@ -1,0 +1,17 @@
+pluginManagement {
+    includeBuild("..")
+    repositories {
+        gradlePluginPortal()
+        google()
+    }
+    val agpVersion: String by settings
+    plugins {
+        id("com.android.library") version agpVersion
+    }
+}
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+        google()
+    }
+}

--- a/test-project-android/settings.gradle.kts
+++ b/test-project-android/settings.gradle.kts
@@ -5,8 +5,10 @@ pluginManagement {
         google()
     }
     val agpVersion: String by settings
-    plugins {
-        id("com.android.library") version agpVersion
+    resolutionStrategy.eachPlugin {
+        if (requested.id.id == "com.android.library") {
+            useModule("com.android.tools.build:gradle:$agpVersion")
+        }
     }
 }
 dependencyResolutionManagement {

--- a/test-project-android/src/main/AndroidManifest.xml
+++ b/test-project-android/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<manifest package="com.kotlinter.example"/>

--- a/test-project-android/src/main/java/org/jmailen/gradle/kotlinter/sample/EmplyClassBodyInJavaSourcesClass.kt
+++ b/test-project-android/src/main/java/org/jmailen/gradle/kotlinter/sample/EmplyClassBodyInJavaSourcesClass.kt
@@ -1,0 +1,4 @@
+package org.jmailen.gradle.kotlinter.sample
+
+class EmplyClassBodyInJavaSourcesClass {
+}

--- a/test-project-android/src/main/kotlin/org/jmailen/gradle/kotlinter/sample/EmplyClassBodyClass.kt
+++ b/test-project-android/src/main/kotlin/org/jmailen/gradle/kotlinter/sample/EmplyClassBodyClass.kt
@@ -1,0 +1,4 @@
+package org.jmailen.gradle.kotlinter.sample
+
+class EmplyClassBodyClass {
+}

--- a/test-project-android/src/test/kotlin/org/jmailen/gradle/kotlinter/sample/OpSpacing.kt
+++ b/test-project-android/src/test/kotlin/org/jmailen/gradle/kotlinter/sample/OpSpacing.kt
@@ -1,0 +1,6 @@
+package org.jmailen.gradle.kotlinter.sample
+
+class OpSpacing {
+
+    val noSpace=Unit
+}

--- a/test-project/build.gradle.kts
+++ b/test-project/build.gradle.kts
@@ -1,4 +1,4 @@
 plugins {
-    kotlin("jvm") version "1.5.31"
+    kotlin("jvm") version "1.6.10"
     id("org.jmailen.kotlinter")
 }


### PR DESCRIPTION
Fixes #228

Seeing the linked issue, I was curious if that's really the case 👀 
I wanted to reproduce the issue in tests, which led me to bumping things to make the whole project be compiled against AGP 7.X and to basically make the project up-to-date again. 
Not sure if you like the changes I'm proposing here. I tried to keep them in separate commits, just in case you want to take only some of them. 

Important note, the changes requires consumers to use AGP 7.0 and up, due to usage of the `.kotlin` extension. If the goal is to maintain old Gradle compatibility then I guess it's required to access kotlin sourcesets in a smarter way)