### PR TITLE
Bump ktlint to 0.45.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,7 @@ description = projectDescription
 object Versions {
     const val androidTools = "7.0.4"
     const val junit = "4.13.2"
-    const val ktlint = "0.44.0"
+    const val ktlint = "0.45.2"
     const val mockitoKotlin = "4.0.0"
 }
 


### PR DESCRIPTION
I might have misunderstood 0.45.0's [release notes](https://github.com/pinterest/ktlint/releases/tag/0.45.0), but it seems like ktlint `0.45.1` ignores passed `userData`. To make the tests pass, I had to use the experimental methods and pass the `indent_size` via `editorConfigOverride` 👀 

Assuming ktlint now has much better integration via `.editorconfig` then maybe it'd make sense to drop the custom `indentSize` extension within the plugin? 