### PR TITLE
Drop 'indentSize'

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,6 @@ Options are configured in the `kotlinter` extension. Defaults shown (you may omi
 ```kotlin
 kotlinter {
     ignoreFailures = false
-    indentSize = 4
     reporters = arrayOf("checkstyle", "plain")
     experimentalRules = false
     disabledRules = emptyArray()
@@ -167,7 +166,6 @@ kotlinter {
 ```groovy
 kotlinter {
     ignoreFailures = false
-    indentSize = 4
     reporters = ['checkstyle', 'plain']
     experimentalRules = false
     disabledRules = []

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterExtension.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterExtension.kt
@@ -12,8 +12,6 @@ open class KotlinterExtension {
 
     var ignoreFailures = DEFAULT_IGNORE_FAILURES
 
-    var indentSize: Int? = null
-
     var reporters = arrayOf(DEFAULT_REPORTER)
 
     var experimentalRules = DEFAULT_EXPERIMENTAL_RULES

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterPlugin.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterPlugin.kt
@@ -47,7 +47,6 @@ class KotlinterPlugin : Plugin<Project> {
                                 }
                             }
                         )
-                        lintTask.indentSize.set(provider { kotlinterExtension.indentSize })
                         lintTask.experimentalRules.set(provider { kotlinterExtension.experimentalRules })
                         lintTask.disabledRules.set(provider { kotlinterExtension.disabledRules.toList() })
                     }
@@ -58,7 +57,6 @@ class KotlinterPlugin : Plugin<Project> {
                     val formatKotlinPerSourceSet = tasks.register("formatKotlin${id.capitalize()}", FormatTask::class.java) { formatTask ->
                         formatTask.source(resolvedSources)
                         formatTask.report.set(reportFile("$id-format.txt"))
-                        formatTask.indentSize.set(provider { kotlinterExtension.indentSize })
                         formatTask.experimentalRules.set(provider { kotlinterExtension.experimentalRules })
                         formatTask.disabledRules.set(provider { kotlinterExtension.disabledRules.toList() })
                     }

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/support/KtLintParams.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/support/KtLintParams.kt
@@ -3,7 +3,6 @@ package org.jmailen.gradle.kotlinter.support
 import java.io.Serializable
 
 data class KtLintParams(
-    val indentSize: Int?,
     val experimentalRules: Boolean,
     val disabledRules: List<String>
 ) : Serializable

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/support/KtLintUserData.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/support/KtLintUserData.kt
@@ -3,9 +3,6 @@ package org.jmailen.gradle.kotlinter.support
 fun userData(ktLintParams: KtLintParams): Map<String, String> {
     val userData = mutableMapOf<String, String>()
 
-    ktLintParams.indentSize?.let { indentSize ->
-        userData["indent_size"] = indentSize.toString()
-    }
     ktLintParams.disabledRules.takeIf { it.isNotEmpty() }?.let { rules ->
         userData["disabled_rules"] = rules.joinToString(",")
     }

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/ConfigurableKtLintTask.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/ConfigurableKtLintTask.kt
@@ -6,7 +6,6 @@ import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.SourceTask
 import org.gradle.internal.exceptions.MultiCauseException
 import org.jmailen.gradle.kotlinter.KotlinterExtension.Companion.DEFAULT_DISABLED_RULES
@@ -16,10 +15,6 @@ import org.jmailen.gradle.kotlinter.support.KtLintParams
 abstract class ConfigurableKtLintTask : SourceTask() {
 
     @Input
-    @Optional
-    val indentSize: Property<Int> = property()
-
-    @Input
     val experimentalRules: Property<Boolean> = property(default = DEFAULT_EXPERIMENTAL_RULES)
 
     @Input
@@ -27,7 +22,6 @@ abstract class ConfigurableKtLintTask : SourceTask() {
 
     @Internal
     protected fun getKtLintParams(): KtLintParams = KtLintParams(
-        indentSize = indentSize.orNull,
         experimentalRules = experimentalRules.get(),
         disabledRules = disabledRules.get()
     )

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/CustomTaskTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/CustomTaskTest.kt
@@ -48,9 +48,9 @@ class CustomTaskTest : WithGradleTest.Kotlin() {
             val validClass =
                 """
                 class CustomClass {
-                     private fun go() {
-                          println("go")
-                     }
+                    private fun go() {
+                        println("go")
+                    }
                 }
                 """.trimIndent()
             writeText(validClass)
@@ -64,7 +64,6 @@ class CustomTaskTest : WithGradleTest.Kotlin() {
                 task ktLint(type: LintTask) {
                     source files('src')
                     reports = ['plain': file('build/lint-report.txt')]
-                    indentSize = 5
                     experimentalRules = true
                     disabledRules = ["final-newline"]
                 }
@@ -113,7 +112,6 @@ class CustomTaskTest : WithGradleTest.Kotlin() {
                 task customizedLintTask(type: LintTask) {
                     source files('src')
                     reports = ['plain': file('build/lint-report.txt')]
-                    indentSize = 123
                     experimentalRules = true
                     disabledRules = ["final-newline"]
                     ignoreFailures = true
@@ -141,7 +139,6 @@ class CustomTaskTest : WithGradleTest.Kotlin() {
     
                 task customizedFormatTask(type: FormatTask) {
                     source files('src')
-                    indentSize = 123
                     experimentalRules = true
                     disabledRules = ["final-newline"]
                 }

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/EditorConfigTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/EditorConfigTest.kt
@@ -52,32 +52,6 @@ internal class EditorConfigTest : WithGradleTest.Kotlin() {
     }
 
     @Test
-    fun `plugin respects indentSize set in editorconfig`() {
-        projectRoot.resolve(".editorconfig") {
-            appendText(
-                """
-                    [*.{kt,kts}]
-                    indent_size = 2
-                """.trimIndent()
-            )
-        }
-        projectRoot.resolve("src/main/kotlin/TwoSpaces.kt") {
-            writeText(
-                """ |
-                    |object TwoSpaces {
-                    |  val text: String
-                    |}
-                    |
-                """.trimMargin()
-            )
-        }
-
-        build("lintKotlin").apply {
-            assertEquals(TaskOutcome.SUCCESS, task(":lintKotlinMain")?.outcome)
-        }
-    }
-
-    @Test
     fun `plugin respects disabled_rules set in editorconfig`() {
         projectRoot.resolve(".editorconfig") {
             appendText(
@@ -97,24 +71,12 @@ internal class EditorConfigTest : WithGradleTest.Kotlin() {
     }
 
     @Test
-    fun `plugin extension properties take precedence over editorconfig values`() {
+    fun `plugin respects 'indent_size' set  in editorconfig`() {
         projectRoot.resolve(".editorconfig") {
             appendText(
                 """
                     [*.{kt,kts}]
-                    disabled_rules=filename
-                    indent_size = 2
-                """.trimIndent()
-            )
-        }
-        projectRoot.resolve("build.gradle") {
-            appendText(
-                """
-                    kotlinter {
-                        disabledRules = ['paren-spacing']  
-                        indentSize = 6
-                    }
-                
+                    indent_size = 6
                 """.trimIndent()
             )
         }
@@ -134,7 +96,6 @@ internal class EditorConfigTest : WithGradleTest.Kotlin() {
 
         buildAndFail("lintKotlin").apply {
             assertEquals(TaskOutcome.FAILED, task(":lintKotlinMain")?.outcome)
-            assertTrue(output.contains("[filename] class WrongFileName should be declared in a file named WrongFileName.kt"))
             assertTrue(output.contains("[indent] Unexpected indentation (2) (should be 6)"))
         }
     }

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/ExtensionTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/ExtensionTest.kt
@@ -55,34 +55,6 @@ internal class ExtensionTest : WithGradleTest.Kotlin() {
     }
 
     @Test
-    fun `extension configures indentSize`() {
-        projectRoot.resolve("build.gradle") {
-            // language=groovy
-            val script =
-                """
-                kotlinter {
-                    indentSize = 2
-                }
-                """.trimIndent()
-            appendText(script)
-        }
-        projectRoot.resolve("src/main/kotlin/TwoSpaces.kt") {
-            writeText(
-                """ |
-                    |object TwoSpaces {
-                    |  val text: String
-                    |}
-                    |
-                """.trimMargin()
-            )
-        }
-
-        build("lintKotlin").apply {
-            assertEquals(TaskOutcome.SUCCESS, task(":lintKotlinMain")?.outcome)
-        }
-    }
-
-    @Test
     fun `extension configures reporters`() {
         projectRoot.resolve("build.gradle") {
             // language=groovy
@@ -154,49 +126,6 @@ internal class ExtensionTest : WithGradleTest.Kotlin() {
 
         build("lintKotlin").apply {
             assertEquals(TaskOutcome.SUCCESS, task(":lintKotlinMain")?.outcome)
-        }
-    }
-
-    @Test
-    fun `user customized values take precedence over extension values`() {
-        projectRoot.resolve("src/main/kotlin/FileName.kt") {
-            // language=kotlin
-            val kotlinClass =
-                """
-                class Precedence {
-                    fun hi() = Unit
-                }
-                """.trimIndent()
-            writeText(kotlinClass)
-        }
-        projectRoot.resolve("build.gradle") {
-            // language=groovy
-            val script =
-                """
-                kotlinter {
-                    disabledRules = ['filename']
-                }
-                
-                lintKotlinMain {
-                    disabledRules = ['final-newline']
-                }
-                
-                """.trimIndent()
-            appendText(script)
-        }
-        // https://github.com/pinterest/ktlint/issues/997
-        projectRoot.resolve(".editorconfig") {
-            val config =
-                """
-                [*.{kt,kts}]
-                indent_size = 4
-                """.trimIndent()
-            appendText(config)
-        }
-
-        buildAndFail("lintKotlin").apply {
-            assertEquals(TaskOutcome.FAILED, task(":lintKotlinMain")?.outcome)
-            assertTrue(output.contains("[filename] class Precedence should be declared in a file named Precedence.kt"))
         }
     }
 }


### PR DESCRIPTION
From the discussion in https://github.com/pinterest/ktlint/issues/1434#issuecomment-1086621945 I understood overriding an `.editorConfig` property via `userData` parameter won't be supported.
According to https://github.com/pinterest/ktlint/pull/1442 passing `indent_size` will result in a runtime exception. Regardless if this lands in current form, in context of the discussion from [previous PR](https://github.com/jeremymailen/kotlinter-gradle/pull/243#issuecomment-1074834159) - I'm proposing to remove the `indentSize` property from Kotlinter's extension.
Regardless of how the future of ktlint will look like, I think such change _makes sense_:
a) `.editorconfig` should be the preferred way of setting the indent_size parameter, mainly because it integrates with IntelliJ based IDEs.
b) it's less code to maintain 😛 

The recommended migration path which probably should be mentioned in release notes is to replace `kotlinter.indentSize` with the following entry in `{project_root}/.editorconfig`:
```editorconfig
[*.{kt, kts}]
indent_size = 4
```