### PR TITLE
introduce ktlintRuleSet configuration (BC break!)

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,17 +337,16 @@ buildscript {
 
 ### Custom Rules
 
-You can add custom ktlint RuleSets using the `buildscript` classpath:
+You can add custom ktlint RuleSets using the `ktlintRuleSet` dependency:
 
 <details open>
 <summary>Kotlin</summary>
 
 ```kotlin
-buildscript {
-    dependencies {
-        classpath(files("libs/my-custom-ktlint-rules.jar"))
-        classpath("org.other.ktlint:custom-rules:1.0")
-    }
+dependencies {
+    ktlintRuleSet(files("libs/my-custom-ktlint-rules.jar"))
+    ktlintRuleSet(project(":ktlint-custom-rules"))
+    ktlintRuleSet("org.other.ktlint:custom-rules:1.0")
 }
 ```
 
@@ -357,11 +356,10 @@ buildscript {
 <summary>Groovy</summary>
 
 ```groovy
-buildscript {
-    dependencies {
-        classpath files('libs/my-custom-ktlint-rules.jar')
-        classpath 'org.other.ktlint:custom-rules:1.0'
-    }
+dependencies {
+    ktlintRuleSet files('libs/my-custom-ktlint-rules.jar')
+    ktlintRuleSet project(':ktlint-custom-rules')
+    ktlintRuleSet 'org.other.ktlint:custom-rules:1.0'
 }
 ```
 

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterPlugin.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterPlugin.kt
@@ -3,6 +3,8 @@ package org.jmailen.gradle.kotlinter
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.attributes.Bundling
 import org.gradle.api.tasks.TaskProvider
 import org.jmailen.gradle.kotlinter.pluginapplier.AndroidSourceSetApplier
 import org.jmailen.gradle.kotlinter.pluginapplier.KotlinJvmSourceSetApplier
@@ -15,6 +17,15 @@ import org.jmailen.gradle.kotlinter.tasks.LintTask
 import java.io.File
 
 class KotlinterPlugin : Plugin<Project> {
+
+    private object Versions {
+        const val ktlint = "0.45.2"
+    }
+
+    companion object {
+        private const val KTLINT_CONFIGURATION_NAME = "ktlint"
+        private const val RULE_SET_CONFIGURATION_NAME = "ktlintRuleSet"
+    }
 
     private val extendablePlugins = mapOf(
         "org.jetbrains.kotlin.jvm" to KotlinJvmSourceSetApplier,
@@ -36,6 +47,9 @@ class KotlinterPlugin : Plugin<Project> {
                 val lintKotlin = registerParentLintTask()
                 val formatKotlin = registerParentFormatTask()
 
+                val ktlintConfiguration = createKtlintConfiguration()
+                val ruleSetConfiguration = createRuleSetConfiguration(ktlintConfiguration)
+
                 sourceResolver.applyToAll(this) { id, resolvedSources ->
                     val lintTaskPerSourceSet = tasks.register("lintKotlin${id.capitalize()}", LintTask::class.java) { lintTask ->
                         lintTask.source(resolvedSources)
@@ -49,6 +63,8 @@ class KotlinterPlugin : Plugin<Project> {
                         )
                         lintTask.experimentalRules.set(provider { kotlinterExtension.experimentalRules })
                         lintTask.disabledRules.set(provider { kotlinterExtension.disabledRules.toList() })
+                        lintTask.ktlintClasspath.setFrom(ktlintConfiguration)
+                        lintTask.ruleSetsClasspath.setFrom(ruleSetConfiguration)
                     }
                     lintKotlin.configure { lintTask ->
                         lintTask.dependsOn(lintTaskPerSourceSet)
@@ -59,6 +75,8 @@ class KotlinterPlugin : Plugin<Project> {
                         formatTask.report.set(reportFile("$id-format.txt"))
                         formatTask.experimentalRules.set(provider { kotlinterExtension.experimentalRules })
                         formatTask.disabledRules.set(provider { kotlinterExtension.disabledRules.toList() })
+                        formatTask.ktlintClasspath.setFrom(ktlintConfiguration)
+                        formatTask.ruleSetsClasspath.setFrom(ruleSetConfiguration)
                     }
                     formatKotlin.configure { formatTask ->
                         formatTask.dependsOn(formatKotlinPerSourceSet)
@@ -93,6 +111,31 @@ class KotlinterPlugin : Plugin<Project> {
             it.group = "build setup"
             it.description = "Installs Kotlinter Git pre-commit hook"
         }
+
+    private fun Project.createKtlintConfiguration(): Configuration = configurations.maybeCreate(KTLINT_CONFIGURATION_NAME).apply {
+        isCanBeResolved = true
+        isCanBeConsumed = false
+        isVisible = false
+
+        val dependencyProvider = provider {
+            this@createKtlintConfiguration.dependencies.create(
+                "com.pinterest:ktlint:${Versions.ktlint}"
+            )
+        }
+
+        dependencies.addLater(dependencyProvider)
+    }
+
+    @Suppress("UnstableApiUsage")
+    private fun Project.createRuleSetConfiguration(
+        ktlintConfiguration: Configuration,
+    ): Configuration = configurations.maybeCreate(RULE_SET_CONFIGURATION_NAME).apply {
+        isCanBeResolved = true
+        isCanBeConsumed = false
+        isVisible = false
+
+        shouldResolveConsistentlyWith(ktlintConfiguration)
+    }
 }
 
 internal val String.id: String

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/FormatTask.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/FormatTask.kt
@@ -1,9 +1,11 @@
 package org.jmailen.gradle.kotlinter.tasks
 
 import org.gradle.api.GradleException
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
+import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
@@ -26,26 +28,40 @@ open class FormatTask @Inject constructor(
     @Optional
     val report: RegularFileProperty = objectFactory.fileProperty()
 
+    @Classpath
+    val ktlintClasspath: ConfigurableFileCollection = objectFactory.fileCollection()
+
+    @Classpath
+    val ruleSetsClasspath: ConfigurableFileCollection = objectFactory.fileCollection()
+
     init {
         outputs.upToDateWhen { false }
     }
 
     @TaskAction
     fun run() {
-        val result = with(workerExecutor.noIsolation()) {
-            submit(FormatWorkerAction::class.java) { p ->
-                p.name.set(name)
-                p.files.from(source)
-                p.projectDirectory.set(projectLayout.projectDirectory.asFile)
-                p.ktLintParams.set(getKtLintParams())
-                p.output.set(report)
+        val workQueue = workerExecutor.processIsolation { spec ->
+            spec.classpath.setFrom(ktlintClasspath, ruleSetsClasspath)
+            spec.forkOptions { options ->
+//                options.maxHeapSize = wor
             }
-            runCatching { await() }
         }
 
-        result.exceptionOrNull()?.workErrorCauses<KotlinterError>()?.ifNotEmpty {
-            forEach { logger.error(it.message, it.cause) }
-            throw GradleException("error formatting sources for $name")
+        workQueue.submit(FormatWorkerAction::class.java) { p ->
+            p.name.set(name)
+            p.files.from(source)
+            p.projectDirectory.set(projectLayout.projectDirectory.asFile)
+            p.ktLintParams.set(getKtLintParams())
+            p.output.set(report)
+        }
+
+        try {
+            workQueue.await()
+        } catch (e: Throwable) {
+            e.workErrorCauses<KotlinterError>().ifNotEmpty {
+                forEach { logger.error(it.message, it.cause) }
+                throw GradleException("error formatting sources for $name")
+            }
         }
     }
 }

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/LintTask.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/LintTask.kt
@@ -1,12 +1,14 @@
 package org.jmailen.gradle.kotlinter.tasks
 
 import org.gradle.api.GradleException
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.FileTree
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputFiles
@@ -42,27 +44,39 @@ open class LintTask @Inject constructor(
     @Input
     val ignoreFailures: Property<Boolean> = objectFactory.property(default = DEFAULT_IGNORE_FAILURES)
 
+    @Classpath
+    val ktlintClasspath: ConfigurableFileCollection = objectFactory.fileCollection()
+
+    @Classpath
+    val ruleSetsClasspath: ConfigurableFileCollection = objectFactory.fileCollection()
+
     @TaskAction
     fun run() {
-        val result = with(workerExecutor.noIsolation()) {
-            submit(LintWorkerAction::class.java) { p ->
-                p.name.set(name)
-                p.files.from(source)
-                p.projectDirectory.set(projectLayout.projectDirectory.asFile)
-                p.reporters.putAll(reports)
-                p.ktLintParams.set(getKtLintParams())
+        val workQueue = workerExecutor.processIsolation { spec ->
+            spec.classpath.setFrom(ktlintClasspath, ruleSetsClasspath)
+            spec.forkOptions { options ->
             }
-            runCatching { await() }
         }
 
-        result.exceptionOrNull()?.workErrorCauses<KotlinterError>()?.ifNotEmpty {
-            forEach { logger.error(it.message, it.cause) }
-            throw GradleException("error linting sources for $name")
+        workQueue.submit(LintWorkerAction::class.java) { p ->
+            p.name.set(name)
+            p.files.from(source)
+            p.projectDirectory.set(projectLayout.projectDirectory.asFile)
+            p.reporters.putAll(reports)
+            p.ktLintParams.set(getKtLintParams())
         }
 
-        val lintFailures = result.exceptionOrNull()?.workErrorCauses<LintFailure>() ?: emptyList()
-        if (lintFailures.isNotEmpty() && !ignoreFailures.get()) {
-            throw GradleException("$name sources failed lint check")
+        try {
+            workQueue.await()
+        } catch (e: Throwable) {
+            e.workErrorCauses<KotlinterError>().ifNotEmpty {
+                forEach { logger.error(it.message, it.cause) }
+                throw GradleException("error linting sources for $name")
+            }
+            val lintFailures = e.workErrorCauses<LintFailure>()
+            if (lintFailures.isNotEmpty() && !ignoreFailures.get()) {
+                throw GradleException("$name sources failed lint check")
+            }
         }
     }
 }

--- a/test-custom-rules/build.gradle.kts
+++ b/test-custom-rules/build.gradle.kts
@@ -1,0 +1,7 @@
+plugins {
+    kotlin("jvm")
+}
+
+dependencies {
+    compileOnly("com.pinterest.ktlint:ktlint-core:0.45.2")
+}

--- a/test-custom-rules/src/main/kotlin/org/jmailen/gradle/kotlinter/customrules/CustomRuleSetProvider.kt
+++ b/test-custom-rules/src/main/kotlin/org/jmailen/gradle/kotlinter/customrules/CustomRuleSetProvider.kt
@@ -1,0 +1,8 @@
+package org.jmailen.gradle.kotlinter.customrules
+
+import com.pinterest.ktlint.core.RuleSet
+import com.pinterest.ktlint.core.RuleSetProvider
+
+class CustomRuleSetProvider : RuleSetProvider {
+    override fun get() = RuleSet("custom-ktlint-rules", NoNewLineBeforeReturnTypeRule())
+}

--- a/test-custom-rules/src/main/kotlin/org/jmailen/gradle/kotlinter/customrules/NoNewLineBeforeReturnTypeRule.kt
+++ b/test-custom-rules/src/main/kotlin/org/jmailen/gradle/kotlinter/customrules/NoNewLineBeforeReturnTypeRule.kt
@@ -1,0 +1,48 @@
+package org.jmailen.gradle.kotlinter.customrules
+
+import com.pinterest.ktlint.core.Rule
+import com.pinterest.ktlint.core.ast.isPartOfComment
+import com.pinterest.ktlint.core.ast.isPartOfString
+import com.pinterest.ktlint.core.ast.nextLeaf
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
+import org.jetbrains.kotlin.psi.KtFunction
+import org.jetbrains.kotlin.psi.KtPrimaryConstructor
+import org.jetbrains.kotlin.psi.KtSecondaryConstructor
+
+class NoNewLineBeforeReturnTypeRule :
+    Rule("no-newline-before-return-type") {
+
+    @Suppress("ComplexCondition")
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
+    ) {
+        if (
+            node !is LeafPsiElement
+            || !node.textMatches(":")
+            || node.isPartOfComment()
+            || node.isPartOfString()
+        ) return
+
+        if (
+            node.parent !is KtFunction
+            || node.parent is KtSecondaryConstructor
+            || node.parent is KtPrimaryConstructor
+        ) return
+
+        val nextLeaf = node.nextLeaf()
+        if (nextLeaf?.textContains('\n') != true) return
+
+        emit(
+            nextLeaf.startOffset,
+            "Unexpected new-line before return type definition.",
+            true
+        )
+
+        if (autoCorrect) {
+            (nextLeaf as LeafPsiElement).rawReplaceWithText(" ")
+        }
+    }
+}

--- a/test-custom-rules/src/main/resources/META-INF/services/com.pinterest.ktlint.core.RuleSetProvider
+++ b/test-custom-rules/src/main/resources/META-INF/services/com.pinterest.ktlint.core.RuleSetProvider
@@ -1,0 +1,1 @@
+org.jmailen.gradle.kotlinter.customrules.CustomRuleSetProvider

--- a/test-project-android/build.gradle.kts
+++ b/test-project-android/build.gradle.kts
@@ -1,9 +1,13 @@
 plugins {
-    kotlin("android") version "1.6.10"
+    kotlin("android") version "1.6.20"
     id("com.android.library")
     id("org.jmailen.kotlinter")
 }
 
 android {
     compileSdkVersion(31)
+}
+
+dependencies {
+    ktlintRuleSet(project(":test-custom-rules"))
 }

--- a/test-project-android/settings.gradle.kts
+++ b/test-project-android/settings.gradle.kts
@@ -17,3 +17,5 @@ dependencyResolutionManagement {
         google()
     }
 }
+include("test-custom-rules")
+project(":test-custom-rules").projectDir = file("../test-custom-rules")

--- a/test-project-android/src/test/kotlin/org/jmailen/gradle/kotlinter/sample/CustomRuleTest.kt
+++ b/test-project-android/src/test/kotlin/org/jmailen/gradle/kotlinter/sample/CustomRuleTest.kt
@@ -1,0 +1,6 @@
+package org.jmailen.gradle.kotlinter.sample
+
+class CustomRuleTest {
+    fun test():
+        Int = 3
+}


### PR DESCRIPTION
The PR brings an easy way to add custom ktlint rules.

Why it is a difficult now:
- There is no way to include other project's module as ktlint ruleset source. https://github.com/jeremymailen/kotlinter-gradle/issues/34
- Using a buildscript is in contradiction with plugins block (a preferred way how to configure project nowadays) and it seems not to be possible to combine them (I'm not fully sure but it didn't worked for me and this seems to be [confirmed here](https://github.com/jeremymailen/kotlinter-gradle/issues/186).)

So overall I've applied the same approach here as it is used in a competitive gradle ktlint plugin we were using previously before switching to this one.