### PR TITLE
find .git repo in parent directory

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,7 @@ object Versions {
     const val junit = "4.13.2"
     const val ktlint = "0.45.2"
     const val mockitoKotlin = "4.0.0"
+    const val jGit = "6.1.0.202203080745-r"
 }
 
 configurations {
@@ -47,6 +48,7 @@ configurations {
 dependencies {
     compileOnly("org.jetbrains.kotlin:kotlin-gradle-plugin")
     compileOnly("com.android.tools.build:gradle:${Versions.androidTools}")
+    implementation("org.eclipse.jgit:org.eclipse.jgit:${Versions.jGit}")
 
     listOf(
         "ktlint-core",

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/GitHookTasks.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/GitHookTasks.kt
@@ -4,6 +4,7 @@ import org.eclipse.jgit.lib.Repository
 import org.eclipse.jgit.lib.RepositoryBuilder
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
@@ -36,13 +37,17 @@ open class InstallPrePushHookTask : InstallHookTask("pre-push") {
  */
 abstract class InstallHookTask(@get:Internal val hookFileName: String) : DefaultTask() {
 
+    @Input
+    val gitDirPath = project.objects.property(default = ".git")
+
     @get:InputDirectory
     internal val projectDir: DirectoryProperty = project.objects.directoryProperty().apply {
         set(project.layout.projectDirectory)
     }
 
     private val gitRepo: Repository =
-        RepositoryBuilder().findGitDir(projectDir.get().asFile).setMustExist(false).build()
+        RepositoryBuilder().findGitDir(projectDir.get().asFile)
+            .setMustExist(false).setGitDir(project.rootProject.file(gitDirPath.get())).build()
 
     @get:Internal
     abstract val hookContent: String


### PR DESCRIPTION
im having trouble to execute installKotlinterPrePushHook in my repository 
because i have .git repo in parent directory than my project placed

it would be nice if kotlinter can find .git repo in parent directories