### PR TITLE
Bump ktlint to 0.46.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,7 @@ description = projectDescription
 object Versions {
     const val androidTools = "7.0.4"
     const val junit = "4.13.2"
-    const val ktlint = "0.45.2"
+    const val ktlint = "0.46.1"
     const val mockitoKotlin = "4.0.0"
 }
 


### PR DESCRIPTION
Bumping `ktlint` to `0.46.1` which is a patch release of the major version `0.46.0`

Release note can be found here for [0.46.0](https://github.com/pinterest/ktlint/releases/tag/0.46.0) and [0.46.1](https://github.com/pinterest/ktlint/releases/tag/0.46.1)