### PR TITLE
Reload Ktlint's caches when `.editorconfig` changes

### DIFF
--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/support/EditorConfigUtils.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/support/EditorConfigUtils.kt
@@ -3,9 +3,9 @@ package org.jmailen.gradle.kotlinter.support
 import com.pinterest.ktlint.core.KtLint
 import com.pinterest.ktlint.core.api.DefaultEditorConfigProperties
 import com.pinterest.ktlint.core.api.EditorConfigOverride
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.logging.Logger
-import org.gradle.api.provider.Property
 import java.io.File
 
 internal fun editorConfigOverride(ktLintParams: KtLintParams): EditorConfigOverride {
@@ -19,12 +19,13 @@ internal fun editorConfigOverride(ktLintParams: KtLintParams): EditorConfigOverr
 }
 
 internal fun resetEditorconfigCacheIfNeeded(
-    wasEditorConfigChanged: Property<Boolean>,
+    changedEditorconfigFiles: ConfigurableFileCollection,
     logger: Logger,
 ) {
-    if (wasEditorConfigChanged.get()) {
+    val changedFiles = changedEditorconfigFiles.files
+    if (changedFiles.any()) {
         logger.info("Editorconfig changed, resetting KtLint caches")
-        KtLint.trimMemory() // Calling trimMemory() will also reset internal loaded `.editorconfig` cache
+        changedFiles.map(File::toPath).forEach(KtLint::reloadEditorConfigFile)
     }
 }
 

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/support/EditorConfigUtils.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/support/EditorConfigUtils.kt
@@ -1,8 +1,11 @@
 package org.jmailen.gradle.kotlinter.support
 
+import com.pinterest.ktlint.core.KtLint
 import com.pinterest.ktlint.core.api.DefaultEditorConfigProperties
 import com.pinterest.ktlint.core.api.EditorConfigOverride
 import org.gradle.api.file.ProjectLayout
+import org.gradle.api.logging.Logger
+import org.gradle.api.provider.Property
 import java.io.File
 
 internal fun editorConfigOverride(ktLintParams: KtLintParams): EditorConfigOverride {
@@ -12,6 +15,16 @@ internal fun editorConfigOverride(ktLintParams: KtLintParams): EditorConfigOverr
         EditorConfigOverride.emptyEditorConfigOverride
     } else {
         EditorConfigOverride.from(DefaultEditorConfigProperties.ktlintDisabledRulesProperty to rules.joinToString(separator = ","))
+    }
+}
+
+internal fun resetEditorconfigCacheIfNeeded(
+    wasEditorConfigChanged: Property<Boolean>,
+    logger: Logger,
+) {
+    if (wasEditorConfigChanged.get()) {
+        logger.info("Editorconfig changed, resetting KtLint caches")
+        KtLint.trimMemory() // Calling trimMemory() will also reset internal loaded `.editorconfig` cache
     }
 }
 

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/ConfigurableKtLintTask.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/ConfigurableKtLintTask.kt
@@ -13,6 +13,8 @@ import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.SourceTask
 import org.gradle.internal.exceptions.MultiCauseException
+import org.gradle.work.Incremental
+import org.gradle.work.InputChanges
 import org.jmailen.gradle.kotlinter.KotlinterExtension.Companion.DEFAULT_DISABLED_RULES
 import org.jmailen.gradle.kotlinter.KotlinterExtension.Companion.DEFAULT_EXPERIMENTAL_RULES
 import org.jmailen.gradle.kotlinter.support.KtLintParams
@@ -31,6 +33,7 @@ abstract class ConfigurableKtLintTask(
 
     @get:InputFiles
     @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:Incremental
     internal val editorconfigFiles: FileCollection = objectFactory.fileCollection().apply {
         from(projectLayout.findApplicableEditorConfigFiles().toList())
     }
@@ -40,6 +43,9 @@ abstract class ConfigurableKtLintTask(
         experimentalRules = experimentalRules.get(),
         disabledRules = disabledRules.get(),
     )
+
+    protected fun wasEditorconfigChanged(inputChanges: InputChanges) =
+        inputChanges.isIncremental && inputChanges.getFileChanges(editorconfigFiles).any()
 }
 
 internal inline fun <reified T> ObjectFactory.property(default: T? = null): Property<T> =

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/ConfigurableKtLintTask.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/ConfigurableKtLintTask.kt
@@ -13,6 +13,7 @@ import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.SourceTask
 import org.gradle.internal.exceptions.MultiCauseException
+import org.gradle.work.FileChange
 import org.gradle.work.Incremental
 import org.gradle.work.InputChanges
 import org.jmailen.gradle.kotlinter.KotlinterExtension.Companion.DEFAULT_DISABLED_RULES
@@ -44,8 +45,12 @@ abstract class ConfigurableKtLintTask(
         disabledRules = disabledRules.get(),
     )
 
-    protected fun wasEditorconfigChanged(inputChanges: InputChanges) =
-        inputChanges.isIncremental && inputChanges.getFileChanges(editorconfigFiles).any()
+    protected fun getChangedEditorconfigFiles(inputChanges: InputChanges) =
+        if (inputChanges.isIncremental) {
+            inputChanges.getFileChanges(editorconfigFiles).map(FileChange::getFile)
+        } else {
+            emptyList()
+        }
 }
 
 internal inline fun <reified T> ObjectFactory.property(default: T? = null): Property<T> =

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/FormatTask.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/FormatTask.kt
@@ -40,7 +40,7 @@ open class FormatTask @Inject constructor(
                 p.projectDirectory.set(projectLayout.projectDirectory.asFile)
                 p.ktLintParams.set(getKtLintParams())
                 p.output.set(report)
-                p.wasEditorConfigChanged.set(wasEditorconfigChanged(inputChanges))
+                p.changedEditorConfigFiles.from(getChangedEditorconfigFiles(inputChanges))
             }
             runCatching { await() }
         }

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/FormatTask.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/FormatTask.kt
@@ -7,6 +7,7 @@ import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
+import org.gradle.work.InputChanges
 import org.gradle.workers.WorkerExecutor
 import org.jetbrains.kotlin.utils.addToStdlib.ifNotEmpty
 import org.jmailen.gradle.kotlinter.support.KotlinterError
@@ -31,7 +32,7 @@ open class FormatTask @Inject constructor(
     }
 
     @TaskAction
-    fun run() {
+    fun run(inputChanges: InputChanges) {
         val result = with(workerExecutor.noIsolation()) {
             submit(FormatWorkerAction::class.java) { p ->
                 p.name.set(name)
@@ -39,6 +40,7 @@ open class FormatTask @Inject constructor(
                 p.projectDirectory.set(projectLayout.projectDirectory.asFile)
                 p.ktLintParams.set(getKtLintParams())
                 p.output.set(report)
+                p.wasEditorConfigChanged.set(wasEditorconfigChanged(inputChanges))
             }
             runCatching { await() }
         }

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/LintTask.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/LintTask.kt
@@ -52,7 +52,7 @@ open class LintTask @Inject constructor(
                 p.projectDirectory.set(projectLayout.projectDirectory.asFile)
                 p.reporters.putAll(reports)
                 p.ktLintParams.set(getKtLintParams())
-                p.wasEditorConfigChanged.set(wasEditorconfigChanged(inputChanges))
+                p.changedEditorconfigFiles.from(getChangedEditorconfigFiles(inputChanges))
             }
             runCatching { await() }
         }

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/LintTask.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/LintTask.kt
@@ -13,6 +13,7 @@ import org.gradle.api.tasks.OutputFiles
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
+import org.gradle.work.InputChanges
 import org.gradle.workers.WorkerExecutor
 import org.jetbrains.kotlin.utils.addToStdlib.ifNotEmpty
 import org.jmailen.gradle.kotlinter.KotlinterExtension.Companion.DEFAULT_IGNORE_FAILURES
@@ -43,7 +44,7 @@ open class LintTask @Inject constructor(
     val ignoreFailures: Property<Boolean> = objectFactory.property(default = DEFAULT_IGNORE_FAILURES)
 
     @TaskAction
-    fun run() {
+    fun run(inputChanges: InputChanges) {
         val result = with(workerExecutor.noIsolation()) {
             submit(LintWorkerAction::class.java) { p ->
                 p.name.set(name)
@@ -51,6 +52,7 @@ open class LintTask @Inject constructor(
                 p.projectDirectory.set(projectLayout.projectDirectory.asFile)
                 p.reporters.putAll(reports)
                 p.ktLintParams.set(getKtLintParams())
+                p.wasEditorConfigChanged.set(wasEditorconfigChanged(inputChanges))
             }
             runCatching { await() }
         }

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/format/FormatWorkerAction.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/format/FormatWorkerAction.kt
@@ -13,6 +13,7 @@ import org.jmailen.gradle.kotlinter.support.KtLintParams
 import org.jmailen.gradle.kotlinter.support.defaultRuleSetProviders
 import org.jmailen.gradle.kotlinter.support.editorConfigOverride
 import org.jmailen.gradle.kotlinter.support.resolveRuleProviders
+import org.jmailen.gradle.kotlinter.support.resetEditorconfigCacheIfNeeded
 import org.jmailen.gradle.kotlinter.tasks.FormatTask
 import java.io.File
 
@@ -25,6 +26,11 @@ abstract class FormatWorkerAction : WorkAction<FormatWorkerParameters> {
     private val output: File? = parameters.output.asFile.orNull
 
     override fun execute() {
+        resetEditorconfigCacheIfNeeded(
+            wasEditorConfigChanged = parameters.wasEditorConfigChanged,
+            logger = logger,
+        )
+
         val fixes = mutableListOf<String>()
         try {
             files.forEach { file ->

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/format/FormatWorkerAction.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/format/FormatWorkerAction.kt
@@ -12,8 +12,8 @@ import org.jmailen.gradle.kotlinter.support.KotlinterError
 import org.jmailen.gradle.kotlinter.support.KtLintParams
 import org.jmailen.gradle.kotlinter.support.defaultRuleSetProviders
 import org.jmailen.gradle.kotlinter.support.editorConfigOverride
-import org.jmailen.gradle.kotlinter.support.resolveRuleProviders
 import org.jmailen.gradle.kotlinter.support.resetEditorconfigCacheIfNeeded
+import org.jmailen.gradle.kotlinter.support.resolveRuleProviders
 import org.jmailen.gradle.kotlinter.tasks.FormatTask
 import java.io.File
 
@@ -27,7 +27,7 @@ abstract class FormatWorkerAction : WorkAction<FormatWorkerParameters> {
 
     override fun execute() {
         resetEditorconfigCacheIfNeeded(
-            wasEditorConfigChanged = parameters.wasEditorConfigChanged,
+            changedEditorconfigFiles = parameters.changedEditorConfigFiles,
             logger = logger,
         )
 

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/format/FormatWorkerParameters.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/format/FormatWorkerParameters.kt
@@ -8,6 +8,7 @@ import org.jmailen.gradle.kotlinter.support.KtLintParams
 
 interface FormatWorkerParameters : WorkParameters {
     val name: Property<String>
+    val wasEditorConfigChanged: Property<Boolean>
     val files: ConfigurableFileCollection
     val projectDirectory: RegularFileProperty
     val ktLintParams: Property<KtLintParams>

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/format/FormatWorkerParameters.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/format/FormatWorkerParameters.kt
@@ -8,7 +8,7 @@ import org.jmailen.gradle.kotlinter.support.KtLintParams
 
 interface FormatWorkerParameters : WorkParameters {
     val name: Property<String>
-    val wasEditorConfigChanged: Property<Boolean>
+    val changedEditorConfigFiles: ConfigurableFileCollection
     val files: ConfigurableFileCollection
     val projectDirectory: RegularFileProperty
     val ktLintParams: Property<KtLintParams>

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/lint/LintWorkerAction.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/lint/LintWorkerAction.kt
@@ -16,6 +16,7 @@ import org.jmailen.gradle.kotlinter.support.editorConfigOverride
 import org.jmailen.gradle.kotlinter.support.reporterFor
 import org.jmailen.gradle.kotlinter.support.reporterPathFor
 import org.jmailen.gradle.kotlinter.support.resolveRuleProviders
+import org.jmailen.gradle.kotlinter.support.resetEditorconfigCacheIfNeeded
 import org.jmailen.gradle.kotlinter.tasks.LintTask
 import java.io.File
 
@@ -30,6 +31,10 @@ abstract class LintWorkerAction : WorkAction<LintWorkerParameters> {
     private val ktLintParams: KtLintParams = parameters.ktLintParams.get()
 
     override fun execute() {
+        resetEditorconfigCacheIfNeeded(
+            wasEditorConfigChanged = parameters.wasEditorConfigChanged,
+            logger = logger,
+        )
         var hasError = false
 
         try {

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/lint/LintWorkerAction.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/lint/LintWorkerAction.kt
@@ -15,8 +15,8 @@ import org.jmailen.gradle.kotlinter.support.defaultRuleSetProviders
 import org.jmailen.gradle.kotlinter.support.editorConfigOverride
 import org.jmailen.gradle.kotlinter.support.reporterFor
 import org.jmailen.gradle.kotlinter.support.reporterPathFor
-import org.jmailen.gradle.kotlinter.support.resolveRuleProviders
 import org.jmailen.gradle.kotlinter.support.resetEditorconfigCacheIfNeeded
+import org.jmailen.gradle.kotlinter.support.resolveRuleProviders
 import org.jmailen.gradle.kotlinter.tasks.LintTask
 import java.io.File
 
@@ -32,7 +32,7 @@ abstract class LintWorkerAction : WorkAction<LintWorkerParameters> {
 
     override fun execute() {
         resetEditorconfigCacheIfNeeded(
-            wasEditorConfigChanged = parameters.wasEditorConfigChanged,
+            changedEditorconfigFiles = parameters.changedEditorconfigFiles,
             logger = logger,
         )
         var hasError = false

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/lint/LintWorkerParameters.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/lint/LintWorkerParameters.kt
@@ -10,6 +10,7 @@ import java.io.File
 
 interface LintWorkerParameters : WorkParameters {
     val name: Property<String>
+    val wasEditorConfigChanged: Property<Boolean>
     val files: ConfigurableFileCollection
     val projectDirectory: RegularFileProperty
     val reporters: MapProperty<String, File>

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/lint/LintWorkerParameters.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/lint/LintWorkerParameters.kt
@@ -10,7 +10,7 @@ import java.io.File
 
 interface LintWorkerParameters : WorkParameters {
     val name: Property<String>
-    val wasEditorConfigChanged: Property<Boolean>
+    val changedEditorconfigFiles: ConfigurableFileCollection
     val files: ConfigurableFileCollection
     val projectDirectory: RegularFileProperty
     val reporters: MapProperty<String, File>

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/EditorConfigTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/EditorConfigTest.kt
@@ -57,9 +57,10 @@ internal class EditorConfigTest : WithGradleTest.Kotlin() {
     fun `plugin respects disabled_rules set in editorconfig`() {
         projectRoot.resolve(".editorconfig") {
             appendText(
+                // language=editorconfig
                 """
                     [*.{kt,kts}]
-                    disabled_rules=filename
+                    ktlint_disabled_rules = filename
                 """.trimIndent(),
             )
         }
@@ -76,6 +77,7 @@ internal class EditorConfigTest : WithGradleTest.Kotlin() {
     fun `plugin respects 'indent_size' set in editorconfig`() {
         projectRoot.resolve(".editorconfig") {
             appendText(
+                // language=editorconfig
                 """
                     [*.{kt,kts}]
                     indent_size = 6
@@ -106,9 +108,10 @@ internal class EditorConfigTest : WithGradleTest.Kotlin() {
     fun `editorconfig changes are taken into account on lint task re-runs`() {
         projectRoot.resolve(".editorconfig") {
             writeText(
+                // language=editorconfig
                 """
                     [*.{kt,kts}]
-                    disabled_rules=filename
+                    ktlint_disabled_rules = filename
                 """.trimIndent(),
             )
         }
@@ -158,9 +161,10 @@ internal class EditorConfigTest : WithGradleTest.Kotlin() {
 
         projectRoot.resolve(".editorconfig") {
             writeText(
+                // language=editorconfig
                 """
                     [*.{kt,kts}]
-                    disabled_rules=filename
+                    ktlint_disabled_rules = filename
                 """.trimIndent(),
             )
         }


### PR DESCRIPTION
Fixes #262

It seems like this was the scenario I mentioned in: https://github.com/jeremymailen/kotlinter-gradle/pull/246#discussion_r841261149 😅 

My proposal is to do basically the same thing as ktlint-gradle does 🤷 Maaybe if https://github.com/pinterest/ktlint/issues/1446 gets addressed we'll get appropriate api to know when something changes (or ktlint will be smart enough to track `.editorconfig` changes)