### PR TITLE
Setup automatic versioning, automatically update Readme.md

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -16,6 +16,8 @@ jobs:
     name: '[${{ matrix.os }}] build plugin'
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Set up Java
         uses: actions/setup-java@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Set up Java
         uses: actions/setup-java@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,3 +30,18 @@ jobs:
           GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
         with:
           arguments: publishPlugins
+
+      - name: Update README.md version references
+        run: sed -i -E 's/version "[[:digit:]]+.[[:digit:]]+.[[:digit:]]+"/version "${{ github.event.release.tag_name }}"/g' README.md
+        shell: bash
+
+      - name: Create Readme version bump Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          commit-message: "Update Readme for the release ${{ github.event.release.tag_name }}"
+          committer: GitHub <noreply@github.com>
+          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          delete-branch: true
+          title: "Update Readme for the release ${{ github.event.release.tag_name }}"
+          body: |
+            Release: https://github.com/${{ github.repository }}/releases/tag/${{ github.event.release.tag_name }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     `maven-publish`
     id("org.jmailen.kotlinter") version "3.12.0"
     idea
+    id("pl.allegro.tech.build.axion-release") version "1.14.2"
 }
 
 repositories {
@@ -15,12 +16,16 @@ repositories {
     google()
 }
 
+scmVersion {
+    tag.prefix.set("")
+}
+
 val pluginId = "org.jmailen.kotlinter"
 val githubUrl = "https://github.com/jeremymailen/kotlinter-gradle"
 val webUrl = "https://github.com/jeremymailen/kotlinter-gradle"
 val projectDescription = "Lint and formatting for Kotlin using ktlint with configuration-free setup on JVM and Android projects"
 
-version = "3.12.0"
+version = scmVersion.version
 group = "org.jmailen.gradle"
 description = projectDescription
 


### PR DESCRIPTION
Here's my proposal of how the release process could be partially automated. My proposal for the new flow is:

1. Create Github release, pick version in format `x.y.z`(or `x.yy.zzz`)
2. Wait until the release gets published on Gradle Plugin Portal
3. Review and merge Automated PR with update Readme version references (example: https://github.com/mateuszkwiecinski/kotlinter-gradle/pull/11)
a. if needed, the branch can be modified manually (i.e. to add a new "compatibility" section)
4. Done ✅ 

The core mechanism for setting proper version is the [Axion Release Plugin](https://github.com/allegro/axion-release-plugin ), which will extract the version from git tags (which is the reason why I have to fetch the repo with tags on checkout)
The plugin registers task`./gradlew currentVersion` (or simply `./gradlew cV`) which allows to view the current version

This plugin also makes _subsequent_ build to have SNAPSHOT version set (if this PR gets merged, HEAD of `master` will return:

![image](https://user-images.githubusercontent.com/36954793/176025430-a0dee51f-a33c-4e77-9ed1-fd7ca1ee2698.png)
)
which is a step towards publishing snapshots 😄 

As an alternative, I could propose doing something similar to what Jake Wharton's [diffuse](https://github.com/JakeWharton/diffuse/blob/7481ff5f5a8af07de13bb4b5a12e509873fa970f/.github/workflows/build.yaml#L41) does - to basically push the tag, and the corresponding workflow will create the release automatically. 

I decided to go with the "automated-PR-after-manual-release" approach as it resembles existing approach the most :) 