### PR TITLE
Make the git hook tasks compatible with configuration cache

### DIFF
--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/GitHookTasks.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/GitHookTasks.kt
@@ -34,19 +34,16 @@ abstract class InstallPrePushHookTask : InstallHookTask("pre-push") {
  */
 abstract class InstallHookTask(@get:Internal val hookFileName: String) : DefaultTask() {
 
-    @get:Input
+    @Input
     val gitDirPath: Property<String> = project.objects.property(default = ".git")
+
+    @Input
+    val rootProjectDir = project.objects.property(default = project.rootProject.rootDir)
 
     @get:Internal
     abstract val hookContent: String
 
-    @get:Input
-    protected abstract val rootProjectDir: Property<File>
-
     init {
-        @Suppress("LeakingThis")
-        rootProjectDir.set(project.rootProject.rootDir)
-
         outputs.upToDateWhen {
             getHookFile()?.readText()?.contains(hookVersion) ?: false
         }

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/GitHookTasks.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/GitHookTasks.kt
@@ -8,7 +8,7 @@ import org.gradle.api.tasks.TaskAction
 import org.jmailen.gradle.kotlinter.support.VersionProperties
 import java.io.File
 
-open class InstallPreCommitHookTask : InstallHookTask("pre-commit") {
+abstract class InstallPreCommitHookTask : InstallHookTask("pre-commit") {
     override val hookContent =
         """
             if ! ${'$'}GRADLEW formatKotlin ; then
@@ -18,7 +18,7 @@ open class InstallPreCommitHookTask : InstallHookTask("pre-commit") {
         """.trimIndent()
 }
 
-open class InstallPrePushHookTask : InstallHookTask("pre-push") {
+abstract class InstallPrePushHookTask : InstallHookTask("pre-push") {
     override val hookContent =
         """
             if ! ${'$'}GRADLEW lintKotlin ; then
@@ -33,13 +33,20 @@ open class InstallPrePushHookTask : InstallHookTask("pre-push") {
  * Install or update a kotlinter-gradle hook.
  */
 abstract class InstallHookTask(@get:Internal val hookFileName: String) : DefaultTask() {
-    @Input
+
+    @get:Input
     val gitDirPath: Property<String> = project.objects.property(default = ".git")
 
     @get:Internal
     abstract val hookContent: String
 
+    @get:Input
+    abstract val rootProjectDir: Property<File>
+
     init {
+        @Suppress("LeakingThis")
+        rootProjectDir.set(project.rootProject.rootDir)
+
         outputs.upToDateWhen {
             getHookFile()?.readText()?.contains(hookVersion) ?: false
         }
@@ -74,7 +81,7 @@ abstract class InstallHookTask(@get:Internal val hookFileName: String) : Default
     }
 
     private fun getHookFile(warn: Boolean = false): File? {
-        val gitDir = project.rootProject.file(gitDirPath.get())
+        val gitDir = File(rootProjectDir.get(), gitDirPath.get())
         if (!gitDir.isDirectory) {
             if (warn) logger.warn("skipping hook creation because $gitDir is not a directory")
             return null
@@ -97,7 +104,7 @@ abstract class InstallHookTask(@get:Internal val hookFileName: String) : Default
             "gradlew"
         }
 
-        val gradlew = File(project.rootDir, gradlewFilename)
+        val gradlew = File(rootProjectDir.get(), gradlewFilename)
         if (gradlew.exists() && gradlew.isFile && gradlew.canExecute()) {
             logger.info("Using gradlew wrapper at ${gradlew.invariantSeparatorsPath}")
             gradlew.invariantSeparatorsPath

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/GitHookTasks.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/GitHookTasks.kt
@@ -41,7 +41,7 @@ abstract class InstallHookTask(@get:Internal val hookFileName: String) : Default
     abstract val hookContent: String
 
     @get:Input
-    abstract val rootProjectDir: Property<File>
+    protected abstract val rootProjectDir: Property<File>
 
     init {
         @Suppress("LeakingThis")

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/WithGradleTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/WithGradleTest.kt
@@ -46,5 +46,5 @@ abstract class WithGradleTest {
 private fun WithGradleTest.defaultRunner(vararg args: String) =
     GradleRunner.create()
         .withProjectDir(testProjectDir.root)
-        .withArguments(args.toList() + "--stacktrace")
+        .withArguments(args.toList() + listOf("--stacktrace", "--configuration-cache"))
         .forwardOutput()


### PR DESCRIPTION
by not acessing the project at execution time.
Run all tests with configuration cache enabled.