### PR TITLE
Bump Ktlint to `0.47.1` (+ bump Kotlin to 1.7.10)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,7 @@ description = projectDescription
 object Versions {
     const val androidTools = "7.2.1"
     const val junit = "4.13.2"
-    const val ktlint = "0.46.1"
+    const val ktlint = "0.47.0"
     const val mockitoKotlin = "4.0.0"
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.kotlin.gradle.plugin.getKotlinPluginVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    kotlin("jvm") version "1.7.0"
+    kotlin("jvm") version "1.7.10"
     id("com.gradle.plugin-publish") version "0.21.0"
     `java-gradle-plugin`
     `maven-publish`

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,7 @@ description = projectDescription
 object Versions {
     const val androidTools = "7.2.1"
     const val junit = "4.13.2"
-    const val ktlint = "0.47.0"
+    const val ktlint = "0.47.1"
     const val mockitoKotlin = "4.0.0"
 }
 

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/support/EditorConfigUtils.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/support/EditorConfigUtils.kt
@@ -11,7 +11,7 @@ internal fun editorConfigOverride(ktLintParams: KtLintParams): EditorConfigOverr
     return if (rules.isEmpty()) {
         EditorConfigOverride.emptyEditorConfigOverride
     } else {
-        EditorConfigOverride.from(DefaultEditorConfigProperties.disabledRulesProperty to rules.joinToString(separator = ","))
+        EditorConfigOverride.from(DefaultEditorConfigProperties.ktlintDisabledRulesProperty to rules.joinToString(separator = ","))
     }
 }
 

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/support/RuleSets.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/support/RuleSets.kt
@@ -1,29 +1,29 @@
 package org.jmailen.gradle.kotlinter.support
 
-import com.pinterest.ktlint.core.RuleSet
-import com.pinterest.ktlint.core.RuleSetProvider
+import com.pinterest.ktlint.core.RuleProvider
+import com.pinterest.ktlint.core.RuleSetProviderV2
 import com.pinterest.ktlint.ruleset.experimental.ExperimentalRuleSetProvider
 import java.util.ServiceLoader
-import kotlin.comparisons.compareBy
 
-fun resolveRuleSets(
-    providers: Iterable<RuleSetProvider>,
+internal fun resolveRuleProviders(
+    providers: Iterable<RuleSetProviderV2>,
     includeExperimentalRules: Boolean = false,
-): List<RuleSet> {
-    return providers
-        .filter { includeExperimentalRules || it !is ExperimentalRuleSetProvider }
-        .map { it.get() }
-        .sortedWith(
-            compareBy {
-                when (it.id) {
-                    "standard" -> 0
-                    else -> 1
-                }
-            },
-        )
-}
+): Set<RuleProvider> = providers
+    .asSequence()
+    .filter { includeExperimentalRules || it !is ExperimentalRuleSetProvider }
+    .sortedWith(
+        compareBy {
+            when (it.id) {
+                "standard" -> 0
+                else -> 1
+            }
+        },
+    )
+    .map(RuleSetProviderV2::getRuleProviders)
+    .flatten()
+    .toSet()
 
 // statically resolve providers from plugin classpath. ServiceLoader#load alone resolves classes lazily which fails when run in parallel
 // https://github.com/jeremymailen/kotlinter-gradle/issues/101
-val defaultRuleSetProviders: List<RuleSetProvider> =
-    ServiceLoader.load(RuleSetProvider::class.java).toList()
+val defaultRuleSetProviders: List<RuleSetProviderV2> =
+    ServiceLoader.load(RuleSetProviderV2::class.java).toList()

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/format/FormatWorkerAction.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/format/FormatWorkerAction.kt
@@ -2,7 +2,7 @@ package org.jmailen.gradle.kotlinter.tasks.format
 
 import com.pinterest.ktlint.core.KtLint
 import com.pinterest.ktlint.core.LintError
-import com.pinterest.ktlint.core.RuleSet
+import com.pinterest.ktlint.core.RuleProvider
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
@@ -12,7 +12,7 @@ import org.jmailen.gradle.kotlinter.support.KotlinterError
 import org.jmailen.gradle.kotlinter.support.KtLintParams
 import org.jmailen.gradle.kotlinter.support.defaultRuleSetProviders
 import org.jmailen.gradle.kotlinter.support.editorConfigOverride
-import org.jmailen.gradle.kotlinter.support.resolveRuleSets
+import org.jmailen.gradle.kotlinter.support.resolveRuleProviders
 import org.jmailen.gradle.kotlinter.tasks.FormatTask
 import java.io.File
 
@@ -28,7 +28,7 @@ abstract class FormatWorkerAction : WorkAction<FormatWorkerParameters> {
         val fixes = mutableListOf<String>()
         try {
             files.forEach { file ->
-                val ruleSets = resolveRuleSets(defaultRuleSetProviders, ktLintParams.experimentalRules)
+                val ruleSets = resolveRuleProviders(defaultRuleSetProviders, ktLintParams.experimentalRules)
                 val sourceText = file.readText()
                 val relativePath = file.toRelativeString(projectDirectory)
 
@@ -68,18 +68,18 @@ abstract class FormatWorkerAction : WorkAction<FormatWorkerParameters> {
         )
     }
 
-    private fun formatKt(file: File, ruleSets: List<RuleSet>, onError: ErrorHandler) =
+    private fun formatKt(file: File, ruleSets: Set<RuleProvider>, onError: ErrorHandler) =
         format(file, ruleSets, onError, false)
 
-    private fun formatKts(file: File, ruleSets: List<RuleSet>, onError: ErrorHandler) =
+    private fun formatKts(file: File, ruleSets: Set<RuleProvider>, onError: ErrorHandler) =
         format(file, ruleSets, onError, true)
 
-    private fun format(file: File, ruleSets: List<RuleSet>, onError: ErrorHandler, script: Boolean): String {
+    private fun format(file: File, ruleProviders: Set<RuleProvider>, onError: ErrorHandler, script: Boolean): String {
         return KtLint.format(
             KtLint.ExperimentalParams(
                 fileName = file.path,
                 text = file.readText(),
-                ruleSets = ruleSets,
+                ruleProviders = ruleProviders,
                 script = script,
                 editorConfigOverride = editorConfigOverride(ktLintParams),
                 cb = { error, corrected ->

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/support/RuleSetsTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/support/RuleSetsTest.kt
@@ -2,9 +2,8 @@ package org.jmailen.gradle.kotlinter.support
 
 import com.pinterest.ktlint.core.KtLint
 import com.pinterest.ktlint.core.Rule
-import com.pinterest.ktlint.core.RuleSet
-import com.pinterest.ktlint.core.RuleSetProvider
-import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import com.pinterest.ktlint.core.RuleProvider
+import com.pinterest.ktlint.core.RuleSetProviderV2
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -13,29 +12,24 @@ class RuleSetsTest {
 
     @Test
     fun `resolveRuleSets loads from classpath providers`() {
-        val result = resolveRuleSets(defaultRuleSetProviders)
+        val standardOnly = resolveRuleProviders(defaultRuleSetProviders, includeExperimentalRules = false)
+        val withExperimentalRules = resolveRuleProviders(defaultRuleSetProviders, includeExperimentalRules = true)
 
-        assertEquals(listOf("standard"), result.map { it.id })
-    }
-
-    @Test
-    fun `resolveRuleSets loads from classpath providers including experimental rules`() {
-        val result = resolveRuleSets(defaultRuleSetProviders, true)
-
-        assertEquals(listOf("standard", "experimental"), result.map { it.id })
+        assertTrue(standardOnly.isNotEmpty())
+        assertTrue(standardOnly.size < withExperimentalRules.size)
     }
 
     @Test
     fun `resolveRuleSets puts standard rules first`() {
-        val standard = TestRuleSetProvider(RuleSet("standard", TestRule("one")))
-        val extra1 = TestRuleSetProvider(RuleSet("extra-one", TestRule("two")))
-        val extra2 = TestRuleSetProvider(RuleSet("extra-two", TestRule("three")))
+        val standard = TestRuleSetProvider("standard", setOf(TestRule("one")))
+        val extra1 = TestRuleSetProvider("extra-one", setOf(TestRule("two")))
+        val extra2 = TestRuleSetProvider("extra-two", setOf(TestRule("three")))
 
-        val result = resolveRuleSets(providers = listOf(extra2, standard, extra1))
+        val result = resolveRuleProviders(providers = listOf(extra2, standard, extra1)).map { it.createNewRuleInstance() }
 
         assertEquals(3, result.size)
-        assertEquals(standard.ruleSet, result.first())
-        assertTrue(result.containsAll(listOf(extra1.ruleSet, extra2.ruleSet)))
+        assertEquals(standard.ruleSet.single(), result.first())
+        assertTrue(result.containsAll(listOf(extra1.ruleSet.single(), extra2.ruleSet.single())))
     }
 
     @Test
@@ -53,21 +47,24 @@ class RuleSetsTest {
                     }
 
                 """.trimIndent(),
-                ruleSets = resolveRuleSets(defaultRuleSetProviders),
+                ruleProviders = resolveRuleProviders(defaultRuleSetProviders),
                 cb = { _, _ -> },
             ),
         )
     }
 }
 
-class TestRuleSetProvider(val ruleSet: RuleSet) : RuleSetProvider {
-    override fun get() = ruleSet
+class TestRuleSetProvider(id: String, val ruleSet: Set<Rule>) : RuleSetProviderV2(
+    id = id,
+    about = About(
+        maintainer = "stub-maintainer",
+        description = "stub-description",
+        license = "stub-license",
+        repositoryUrl = "stub-repositoryUrl",
+        issueTrackerUrl = "stub-issueTrackerUrl",
+    ),
+) {
+    override fun getRuleProviders() = ruleSet.map { rule -> RuleProvider(provider = { rule }) }.toSet()
 }
 
-class TestRule(id: String) : Rule(id) {
-    override fun visit(
-        node: ASTNode,
-        autoCorrect: Boolean,
-        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit,
-    ) = Unit
-}
+class TestRule(id: String) : Rule(id)

--- a/test-project-android/build.gradle.kts
+++ b/test-project-android/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("android") version "1.7.0"
+    kotlin("android") version "1.7.10"
     id("com.android.library")
     id("org.jmailen.kotlinter")
 }

--- a/test-project/build.gradle.kts
+++ b/test-project/build.gradle.kts
@@ -1,4 +1,4 @@
 plugins {
-    kotlin("jvm") version "1.7.0"
+    kotlin("jvm") version "1.7.10"
     id("org.jmailen.kotlinter")
 }


### PR DESCRIPTION
The latest version of Ktlint deprecates some of the classes the plugin uses, so I migrated the code to the _new_ apis. 

This means Kotlinter will require Ktlint `0.47.0` and up 👀 