### PR TITLE
Bump kotlinter 3.12.0 + update integration test matrix

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,9 @@
+root = true
+
 [*.{kt,kts}]
 max_line_length = 140
 indent_size = 4
 insert_final_newline = true
 ij_kotlin_allow_trailing_comma = true
 ij_kotlin_allow_trailing_comma_on_call_site = true
-disabled_rules=filename
+ktlint_disabled_rules = filename

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -77,14 +77,27 @@ jobs:
           gradle-version: ${{ matrix.gradle }}
           arguments: formatKotlin lintKotlin
 
+  provide-agp-version-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      agp-versions: ${{ steps.build-agp-matrix.outputs.agp-versions }}
+    steps:
+      - id: agp-version-finder
+        uses: usefulness/agp-version-finder-action@v1
+
+      - id: build-agp-matrix
+        run: echo '::set-output name=agp-versions::["${{ steps.agp-version-finder.outputs.latest-stable }}", "${{ steps.agp-version-finder.outputs.latest-alpha }}"]'
+
   integration-tests-android:
     runs-on: ubuntu-latest
+    needs:
+      - provide-agp-version-matrix
     strategy:
       fail-fast: false
       matrix:
         gradle: [ current ]
         java: [ 17 ]
-        agp: [ 7.0.4 ]
+        agp: ${{ fromJSON(needs.provide-agp-version-matrix.outputs.agp-versions) }}
         include:
           - gradle: 7.0.1
             java: 11

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -77,6 +77,19 @@ jobs:
           gradle-version: ${{ matrix.gradle }}
           arguments: formatKotlin lintKotlin
 
+      - name: Assert fixes
+        run: |
+          cd test-project/build/reports/ktlint
+          grep 'no-empty-class-body' main-format.txt | grep -q 'EmptyClassBodyClass.kt:3:27'
+          grep 'op-spacing' test-format.txt | grep -q 'OpSpacing.kt:5:16'
+
+      - name: Upload reports
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: "test-project-reports-${{ matrix.os }}-${{ matrix.gradle }}-${{ matrix.java }}"
+          path: "${{ github.workspace }}/**/build/reports/ktlint"
+
   provide-agp-version-matrix:
     runs-on: ubuntu-latest
     outputs:
@@ -123,3 +136,17 @@ jobs:
           build-root-directory: test-project-android
           gradle-version: ${{ matrix.gradle }}
           arguments: formatKotlin lintKotlin -PagpVersion=${{ matrix.agp }}
+
+      - name: Assert fixes
+        run: |
+          cd test-project-android/build/reports/ktlint
+          grep 'no-empty-class-body' main-format.txt | grep -q 'EmptyClassBodyClass.kt:3:27'
+          grep 'no-empty-class-body' main-format.txt | grep -q 'EmptyClassBodyInJavaSourcesClass.kt:3:40'
+          grep 'op-spacing' test-format.txt | grep -q 'OpSpacing.kt:5:16'
+
+      - name: Upload reports
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: "test-project-android-reports-${{ matrix.gradle }}-${{ matrix.java }}-${{ matrix.agp }}"
+          path: "${{ github.workspace }}/**/build/reports/ktlint"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     id("com.gradle.plugin-publish") version "0.21.0"
     `java-gradle-plugin`
     `maven-publish`
-    id("org.jmailen.kotlinter") version "3.11.1"
+    id("org.jmailen.kotlinter") version "3.12.0"
     idea
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,7 @@ group = "org.jmailen.gradle"
 description = projectDescription
 
 object Versions {
-    const val androidTools = "7.2.1"
+    const val androidTools = "7.2.2"
     const val junit = "4.13.2"
     const val ktlint = "0.47.1"
     const val mockitoKotlin = "4.0.0"

--- a/test-project-android/build.gradle.kts
+++ b/test-project-android/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 android {
-    compileSdkVersion(31)
+    compileSdkVersion(33)
 
     if (properties["agpVersion"].toString().startsWith("4")) {
         sourceSets {

--- a/test-project-android/build.gradle.kts
+++ b/test-project-android/build.gradle.kts
@@ -6,4 +6,11 @@ plugins {
 
 android {
     compileSdkVersion(31)
+
+    if (properties["agpVersion"].toString().startsWith("4")) {
+        sourceSets {
+            named("main") { java.srcDirs("src/main/kotlin") }
+            named("test") { java.srcDirs("src/test/kotlin") }
+        }
+    }
 }

--- a/test-project-android/src/main/java/org/jmailen/gradle/kotlinter/sample/EmptyClassBodyInJavaSourcesClass.kt
+++ b/test-project-android/src/main/java/org/jmailen/gradle/kotlinter/sample/EmptyClassBodyInJavaSourcesClass.kt
@@ -1,4 +1,4 @@
 package org.jmailen.gradle.kotlinter.sample
 
-class EmplyClassBodyClass {
+class EmptyClassBodyInJavaSourcesClass {
 }

--- a/test-project-android/src/main/kotlin/org/jmailen/gradle/kotlinter/sample/EmptyClassBodyClass.kt
+++ b/test-project-android/src/main/kotlin/org/jmailen/gradle/kotlinter/sample/EmptyClassBodyClass.kt
@@ -1,4 +1,4 @@
 package org.jmailen.gradle.kotlinter.sample
 
-class EmplyClassBodyClass {
+class EmptyClassBodyClass {
 }

--- a/test-project/src/main/kotlin/org/jmailen/gradle/kotlinter/sample/EmptyClassBodyClass.kt
+++ b/test-project/src/main/kotlin/org/jmailen/gradle/kotlinter/sample/EmptyClassBodyClass.kt
@@ -1,4 +1,4 @@
 package org.jmailen.gradle.kotlinter.sample
 
-class EmplyClassBodyInJavaSourcesClass {
+class EmptyClassBodyClass {
 }


### PR DESCRIPTION
1. Bump `kotlinter-gradle` to recently released `3.12.0`
2. Run android integration tests against dynamically set latest `stable` and `alpha` AGP versions:
3. Seeing changes in #250, improve integration tests verification by failing the workflow if expected ktlint check wasn't verified. My idea here is to verify the custom check was invoked, as expected. 