### PR TITLE
Migrate to JUnit5 + bump AGP to 7.3.0 + bump Kotlin to 1.7.20

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,7 @@ group = "org.jmailen.gradle"
 description = projectDescription
 
 object Versions {
-    const val androidTools = "7.2.2"
+    const val androidTools = "7.3.0"
     const val junit = "5.9.1"
     const val ktlint = "0.47.1"
     const val mockitoKotlin = "4.0.0"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.kotlin.gradle.plugin.getKotlinPluginVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    kotlin("jvm") version "1.7.10"
+    kotlin("jvm") version "1.7.20"
     id("com.gradle.plugin-publish") version "0.21.0"
     `java-gradle-plugin`
     `maven-publish`

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,7 @@ description = projectDescription
 
 object Versions {
     const val androidTools = "7.2.2"
-    const val junit = "4.13.2"
+    const val junit = "5.9.1"
     const val ktlint = "0.47.1"
     const val mockitoKotlin = "4.0.0"
 }
@@ -66,7 +66,8 @@ dependencies {
         implementation("com.pinterest.ktlint:$module:${Versions.ktlint}")
     }
 
-    testImplementation("junit:junit:${Versions.junit}")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${Versions.junit}")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:${Versions.junit}")
     testImplementation("org.mockito.kotlin:mockito-kotlin:${Versions.mockitoKotlin}")
 }
 
@@ -102,6 +103,9 @@ tasks {
             languageVersion = "1.4"
             jvmTarget = targetJavaVersion.toString()
         }
+    }
+    withType<Test>().configureEach {
+        useJUnitPlatform()
     }
 
     // Required to put the Kotlin plugin on the classpath for the functional test suite

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,6 +68,7 @@ dependencies {
 
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${Versions.junit}")
     testImplementation("org.junit.jupiter:junit-jupiter-api:${Versions.junit}")
+    implementation("commons-io:commons-io:2.11.0")
     testImplementation("org.mockito.kotlin:mockito-kotlin:${Versions.mockitoKotlin}")
 }
 

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/AndroidProjectTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/AndroidProjectTest.kt
@@ -15,7 +15,7 @@ internal class AndroidProjectTest : WithGradleTest.Android() {
 
     @BeforeEach
     fun setUp() {
-        testProjectDir.root.apply {
+        testProjectDir.apply {
             resolve("settings.gradle") { writeText(settingsFile) }
             resolve("build.gradle") {
                 // language=groovy

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/AndroidProjectTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/AndroidProjectTest.kt
@@ -4,16 +4,16 @@ import org.gradle.testkit.runner.TaskOutcome
 import org.jmailen.gradle.kotlinter.functional.utils.androidManifest
 import org.jmailen.gradle.kotlinter.functional.utils.kotlinClass
 import org.jmailen.gradle.kotlinter.functional.utils.resolve
-import org.junit.Assert.assertEquals
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import java.io.File
 
 internal class AndroidProjectTest : WithGradleTest.Android() {
 
     private lateinit var androidModuleRoot: File
 
-    @Before
+    @BeforeEach
     fun setUp() {
         testProjectDir.root.apply {
             resolve("settings.gradle") { writeText(settingsFile) }

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/CustomTaskTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/CustomTaskTest.kt
@@ -5,18 +5,18 @@ import org.jmailen.gradle.kotlinter.functional.utils.editorConfig
 import org.jmailen.gradle.kotlinter.functional.utils.kotlinClass
 import org.jmailen.gradle.kotlinter.functional.utils.resolve
 import org.jmailen.gradle.kotlinter.functional.utils.settingsFile
-import org.junit.Assert.assertArrayEquals
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import java.io.File
 
 class CustomTaskTest : WithGradleTest.Kotlin() {
 
     lateinit var projectRoot: File
 
-    @Before
+    @BeforeEach
     fun setUp() {
         projectRoot = testProjectDir.root.apply {
             resolve("settings.gradle") { writeText(settingsFile) }

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/CustomTaskTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/CustomTaskTest.kt
@@ -18,7 +18,7 @@ class CustomTaskTest : WithGradleTest.Kotlin() {
 
     @BeforeEach
     fun setUp() {
-        projectRoot = testProjectDir.root.apply {
+        projectRoot = testProjectDir.apply {
             resolve("settings.gradle") { writeText(settingsFile) }
             resolve("build.gradle") {
                 // language=groovy

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/EditorConfigTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/EditorConfigTest.kt
@@ -18,7 +18,7 @@ internal class EditorConfigTest : WithGradleTest.Kotlin() {
 
     @BeforeEach
     fun setUp() {
-        projectRoot = testProjectDir.root.apply {
+        projectRoot = testProjectDir.apply {
             resolve("settings.gradle") { writeText(settingsFile) }
             resolve("build.gradle") {
                 // language=groovy

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/EditorConfigTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/EditorConfigTest.kt
@@ -5,18 +5,18 @@ import org.jmailen.gradle.kotlinter.functional.utils.editorConfig
 import org.jmailen.gradle.kotlinter.functional.utils.kotlinClass
 import org.jmailen.gradle.kotlinter.functional.utils.resolve
 import org.jmailen.gradle.kotlinter.functional.utils.settingsFile
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import java.io.File
 
 internal class EditorConfigTest : WithGradleTest.Kotlin() {
 
     lateinit var projectRoot: File
 
-    @Before
+    @BeforeEach
     fun setUp() {
         projectRoot = testProjectDir.root.apply {
             resolve("settings.gradle") { writeText(settingsFile) }

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/ExtensionTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/ExtensionTest.kt
@@ -16,7 +16,7 @@ internal class ExtensionTest : WithGradleTest.Kotlin() {
 
     @BeforeEach
     fun setUp() {
-        projectRoot = testProjectDir.root.apply {
+        projectRoot = testProjectDir.apply {
             resolve("settings.gradle") { writeText(settingsFile) }
             resolve("build.gradle") {
                 // language=groovy

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/ExtensionTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/ExtensionTest.kt
@@ -4,17 +4,17 @@ import org.gradle.testkit.runner.TaskOutcome
 import org.jmailen.gradle.kotlinter.functional.utils.kotlinClass
 import org.jmailen.gradle.kotlinter.functional.utils.resolve
 import org.jmailen.gradle.kotlinter.functional.utils.settingsFile
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import java.io.File
 
 internal class ExtensionTest : WithGradleTest.Kotlin() {
 
     lateinit var projectRoot: File
 
-    @Before
+    @BeforeEach
     fun setUp() {
         projectRoot = testProjectDir.root.apply {
             resolve("settings.gradle") { writeText(settingsFile) }

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/InstallHookTaskTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/InstallHookTaskTest.kt
@@ -20,7 +20,7 @@ abstract class InstallHookTaskTest(
 
     @BeforeEach
     fun setup() {
-        projectRoot = testProjectDir.root.apply {
+        projectRoot = testProjectDir.apply {
             resolve("settings.gradle") { writeText(settingsFile) }
             resolve("build.gradle") {
                 writeText(
@@ -39,11 +39,11 @@ abstract class InstallHookTaskTest(
 
     @Test
     fun `installs hook in project without hook directory`() {
-        File(testProjectDir.root, ".git").apply { mkdir() }
+        File(testProjectDir, ".git").apply { mkdir() }
 
         build(taskName).apply {
             assertEquals(SUCCESS, task(":$taskName")?.outcome)
-            testProjectDir.root.apply {
+            testProjectDir.apply {
                 resolve(".git/hooks/$hookFile") {
                     assertTrue(readText().contains("${'$'}GRADLEW formatKotlin"))
                     assertTrue(canExecute())
@@ -59,14 +59,14 @@ abstract class InstallHookTaskTest(
                 #!/bin/bash
                 This is some existing hook
             """.trimIndent()
-        File(testProjectDir.root, ".git/hooks").apply { mkdirs() }
-        File(testProjectDir.root, ".git/hooks/$hookFile").apply {
+        File(testProjectDir, ".git/hooks").apply { mkdirs() }
+        File(testProjectDir, ".git/hooks/$hookFile").apply {
             writeText(existingHook)
         }
 
         build(taskName).apply {
             assertEquals(SUCCESS, task(":$taskName")?.outcome)
-            testProjectDir.root.apply {
+            testProjectDir.apply {
                 resolve(".git/hooks/$hookFile") {
                     val hookContents = readText()
                     assertTrue(hookContents.startsWith(existingHook))
@@ -79,8 +79,8 @@ abstract class InstallHookTaskTest(
     @Test
     fun `updates previously installed kotlinter hook`() {
         val placeholder = "Not actually the hook, just a placeholder"
-        File(testProjectDir.root, ".git/hooks").apply { mkdirs() }
-        File(testProjectDir.root, ".git/hooks/$hookFile").apply {
+        File(testProjectDir, ".git/hooks").apply { mkdirs() }
+        File(testProjectDir, ".git/hooks/$hookFile").apply {
             writeText(
                 """
                 ${InstallHookTask.startHook}
@@ -92,7 +92,7 @@ abstract class InstallHookTaskTest(
 
         build(taskName).apply {
             assertEquals(SUCCESS, task(":$taskName")?.outcome)
-            testProjectDir.root.apply {
+            testProjectDir.apply {
                 resolve(".git/hooks/$hookFile") {
                     val hookContents = readText()
                     assertTrue(hookContents.contains("${'$'}GRADLEW formatKotlin"))
@@ -104,11 +104,11 @@ abstract class InstallHookTaskTest(
 
     @Test
     fun `up-to-date when after hook installed`() {
-        File(testProjectDir.root, ".git").apply { mkdir() }
+        File(testProjectDir, ".git").apply { mkdir() }
         lateinit var hookContent: String
         build(taskName).apply {
             assertEquals(SUCCESS, task(":$taskName")?.outcome)
-            testProjectDir.root.apply {
+            testProjectDir.apply {
                 resolve(".git/hooks/$hookFile") {
                     hookContent = readText()
                     println(hookContent)
@@ -120,7 +120,7 @@ abstract class InstallHookTaskTest(
 
         build(taskName).apply {
             assertEquals(UP_TO_DATE, task(":$taskName")?.outcome)
-            testProjectDir.root.apply {
+            testProjectDir.apply {
                 resolve(".git/hooks/$hookFile") {
                     assertEquals(hookContent, readText())
                 }

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/InstallHookTaskTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/InstallHookTaskTest.kt
@@ -5,11 +5,11 @@ import org.gradle.testkit.runner.TaskOutcome.UP_TO_DATE
 import org.jmailen.gradle.kotlinter.functional.utils.resolve
 import org.jmailen.gradle.kotlinter.functional.utils.settingsFile
 import org.jmailen.gradle.kotlinter.tasks.InstallHookTask
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import java.io.File
 
 abstract class InstallHookTaskTest(
@@ -18,7 +18,7 @@ abstract class InstallHookTaskTest(
 ) : WithGradleTest.Kotlin() {
     private lateinit var projectRoot: File
 
-    @Before
+    @BeforeEach
     fun setup() {
         projectRoot = testProjectDir.root.apply {
             resolve("settings.gradle") { writeText(settingsFile) }

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/KotlinProjectTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/KotlinProjectTest.kt
@@ -4,10 +4,10 @@ import org.gradle.testkit.runner.TaskOutcome.FAILED
 import org.gradle.testkit.runner.TaskOutcome.SUCCESS
 import org.gradle.testkit.runner.TaskOutcome.UP_TO_DATE
 import org.jmailen.gradle.kotlinter.functional.utils.editorConfig
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import java.io.File
 
 internal class KotlinProjectTest : WithGradleTest.Kotlin() {
@@ -18,12 +18,12 @@ internal class KotlinProjectTest : WithGradleTest.Kotlin() {
     private lateinit var editorconfigFile: File
     private val pathPattern = "(.*\\.kt):\\d+:\\d+".toRegex()
 
-    @Before
+    @BeforeEach
     fun setup() {
-        settingsFile = testProjectDir.newFile("settings.gradle")
-        buildFile = testProjectDir.newFile("build.gradle")
-        sourceDir = testProjectDir.newFolder("src", "main", "kotlin")
-        editorconfigFile = testProjectDir.newFile(".editorconfig")
+        settingsFile = testProjectDir.resolve("settings.gradle")
+        buildFile = testProjectDir.resolve("build.gradle")
+        sourceDir = testProjectDir.resolve("src/main/kotlin/").also(File::mkdirs)
+        editorconfigFile = testProjectDir.resolve(".editorconfig")
     }
 
     @Test

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/ModifiedSourceSetsTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/ModifiedSourceSetsTest.kt
@@ -4,9 +4,9 @@ import org.gradle.testkit.runner.TaskOutcome
 import org.jmailen.gradle.kotlinter.functional.utils.androidManifest
 import org.jmailen.gradle.kotlinter.functional.utils.kotlinClass
 import org.jmailen.gradle.kotlinter.functional.utils.resolve
-import org.junit.Assert.assertEquals
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import java.io.File
 
 internal class ModifiedSourceSetsTest : WithGradleTest.Android() {
@@ -14,7 +14,7 @@ internal class ModifiedSourceSetsTest : WithGradleTest.Android() {
     private lateinit var androidModuleRoot: File
     private lateinit var kotlinModuleRoot: File
 
-    @Before
+    @BeforeEach
     fun setUp() {
         testProjectDir.root.apply {
             resolve("settings.gradle") { writeText(settingsFile) }

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/ModifiedSourceSetsTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/ModifiedSourceSetsTest.kt
@@ -16,7 +16,7 @@ internal class ModifiedSourceSetsTest : WithGradleTest.Android() {
 
     @BeforeEach
     fun setUp() {
-        testProjectDir.root.apply {
+        testProjectDir.apply {
             resolve("settings.gradle") { writeText(settingsFile) }
             resolve("build.gradle") {
                 // language=groovy

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/WithGradleTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/WithGradleTest.kt
@@ -7,8 +7,6 @@ import org.gradle.testkit.runner.internal.PluginUnderTestMetadataReading
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
 
-val File.root get() = this
-
 abstract class WithGradleTest {
 
     @TempDir

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/WithGradleTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/WithGradleTest.kt
@@ -1,16 +1,31 @@
 package org.jmailen.gradle.kotlinter.functional
 
+import org.apache.commons.io.FileUtils
 import org.gradle.internal.classpath.DefaultClassPath
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.internal.PluginUnderTestMetadataReading
-import org.junit.jupiter.api.io.TempDir
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import java.io.File
+import java.nio.file.Files
 
 abstract class WithGradleTest {
 
-    @TempDir
     lateinit var testProjectDir: File
+
+    /**
+     * Not using JUnit's @TempDir, due do https://github.com/gradle/gradle/issues/12535
+     */
+    @BeforeEach
+    internal fun setUpTempdir() {
+        testProjectDir = Files.createTempDirectory(this::class.java.simpleName).toFile()
+    }
+
+    @AfterEach
+    internal fun cleanUpTempdir() {
+        FileUtils.forceDeleteOnExit(testProjectDir)
+    }
 
     protected fun build(vararg args: String): BuildResult = gradleRunnerFor(*args).build()
 

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/WithGradleTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/WithGradleTest.kt
@@ -4,13 +4,15 @@ import org.gradle.internal.classpath.DefaultClassPath
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.internal.PluginUnderTestMetadataReading
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+val File.root get() = this
 
 abstract class WithGradleTest {
 
-    @get:Rule
-    val testProjectDir = TemporaryFolder()
+    @TempDir
+    lateinit var testProjectDir: File
 
     protected fun build(vararg args: String): BuildResult = gradleRunnerFor(*args).build()
 
@@ -45,6 +47,6 @@ abstract class WithGradleTest {
 
 private fun WithGradleTest.defaultRunner(vararg args: String) =
     GradleRunner.create()
-        .withProjectDir(testProjectDir.root)
+        .withProjectDir(testProjectDir)
         .withArguments(args.toList() + listOf("--stacktrace", "--configuration-cache"))
         .forwardOutput()

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/support/ReportersTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/support/ReportersTest.kt
@@ -1,7 +1,8 @@
 package org.jmailen.gradle.kotlinter.support
 
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import java.io.File
 
 class ReportersTest {
@@ -15,9 +16,9 @@ class ReportersTest {
         assertEquals("html", reporterFileExtension("html"))
     }
 
-    @Test(expected = IllegalArgumentException::class)
+    @Test
     fun testUnknownReporterExtension() {
-        reporterFileExtension("unknown")
+        assertThrows<IllegalArgumentException> { reporterFileExtension("unknown") }
     }
 
     @Test

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/support/RuleSetsTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/support/RuleSetsTest.kt
@@ -4,9 +4,9 @@ import com.pinterest.ktlint.core.KtLint
 import com.pinterest.ktlint.core.Rule
 import com.pinterest.ktlint.core.RuleProvider
 import com.pinterest.ktlint.core.RuleSetProviderV2
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
 
 class RuleSetsTest {
 

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/support/SortedThreadSafeReporterWrapperTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/support/SortedThreadSafeReporterWrapperTest.kt
@@ -2,8 +2,8 @@ package org.jmailen.gradle.kotlinter.support
 
 import com.pinterest.ktlint.core.LintError
 import com.pinterest.ktlint.core.Reporter
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.mockito.Mockito.verify
 import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
@@ -15,7 +15,7 @@ class SortedThreadSafeReporterWrapperTest {
 
     private lateinit var reporter: SortedThreadSafeReporterWrapper
 
-    @Before
+    @BeforeEach
     fun setUp() {
         wrapped = mock()
 

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/tasks/GenerateHookTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/tasks/GenerateHookTest.kt
@@ -1,8 +1,8 @@
 package org.jmailen.gradle.kotlinter.tasks
 
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
 
 internal class GenerateHookTest {
     private val gradlew = "gradlewLocation"

--- a/test-project-android/build.gradle.kts
+++ b/test-project-android/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("android") version "1.7.10"
+    kotlin("android") version "1.7.20"
     id("com.android.library")
     id("org.jmailen.kotlinter")
 }

--- a/test-project/build.gradle.kts
+++ b/test-project/build.gradle.kts
@@ -1,4 +1,4 @@
 plugins {
-    kotlin("jvm") version "1.7.10"
+    kotlin("jvm") version "1.7.20"
     id("org.jmailen.kotlinter")
 }


### PR DESCRIPTION
In #279, I'll want to temporarily disable some tests onWindows due to Gradle test-kit bug: https://github.com/gradle/gradle/issues/21964 
JUnit5 has a dedicated [DisabledOnOs](https://junit.org/junit5/docs/5.2.0/api/org/junit/jupiter/api/condition/DisabledOnOs.html) annotation, so I'm proposing to upgrate test suite to run with JUnit5, which would be nice to do even if I didn't need the new annotation :)