### PR TITLE
Run workflows against alpha AGP version only on the main branch + fix android test project 

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -99,7 +99,12 @@ jobs:
         uses: usefulness/agp-version-finder-action@v1
 
       - id: build-agp-matrix
-        run: echo '::set-output name=agp-versions::["${{ steps.agp-version-finder.outputs.latest-stable }}", "${{ steps.agp-version-finder.outputs.latest-alpha }}"]'
+        run: |
+           if [[ ${{ github.event_name }} == 'pull_request' ]]; then
+             echo '::set-output name=agp-versions::["${{ steps.agp-version-finder.outputs.latest-stable }}"]'
+           else
+             echo '::set-output name=agp-versions::["${{ steps.agp-version-finder.outputs.latest-stable }}", "${{ steps.agp-version-finder.outputs.latest-alpha }}"]'
+           fi
 
   integration-tests-android:
     runs-on: ubuntu-latest

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -101,9 +101,9 @@ jobs:
       - id: build-agp-matrix
         run: |
            if [[ ${{ github.event_name }} == 'pull_request' ]]; then
-             echo '::set-output name=agp-versions::["${{ steps.agp-version-finder.outputs.latest-stable }}"]'
+             echo 'agp-versions=["${{ steps.agp-version-finder.outputs.latest-stable }}"]' >> $GITHUB_OUTPUT
            else
-             echo '::set-output name=agp-versions::["${{ steps.agp-version-finder.outputs.latest-stable }}", "${{ steps.agp-version-finder.outputs.latest-alpha }}"]'
+             echo 'agp-versions=["${{ steps.agp-version-finder.outputs.latest-stable }}", "${{ steps.agp-version-finder.outputs.latest-alpha }}"]' >> $GITHUB_OUTPUT
            fi
 
   integration-tests-android:

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -115,9 +115,6 @@ jobs:
           - gradle: 7.0.1
             java: 11
             agp: 4.2.2
-          - gradle: 6.9.1
-            java: 8
-            agp: 4.0.0
 
     name: '[android] Gradle: ${{ matrix.gradle }}, Java: ${{ matrix.java }}, AGP: ${{ matrix.agp }}'
     steps:

--- a/test-project-android/build.gradle.kts
+++ b/test-project-android/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 
 android {
     compileSdkVersion(33)
+    namespace = "com.kotlinter.example"
 
     if (properties["agpVersion"].toString().startsWith("4")) {
         sourceSets {

--- a/test-project-android/src/main/AndroidManifest.xml
+++ b/test-project-android/src/main/AndroidManifest.xml
@@ -1,2 +1,0 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<manifest package="com.kotlinter.example"/>


### PR DESCRIPTION
As discussed in: https://github.com/jeremymailen/kotlinter-gradle/pull/290#issuecomment-1283038262