### PR TITLE
Fix wrong `apache-commons` dependency + fix CI deprecation warnings

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -15,10 +15,10 @@ jobs:
         os: [ ubuntu-latest, windows-latest ]
     name: '[${{ matrix.os }}] build plugin'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: 'adopt'
           java-version: 17
@@ -38,7 +38,7 @@ jobs:
 
       - name: Upload test results
         if: ${{ always() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: test-results-${{ matrix.os }}
           path: "${{ github.workspace }}/**/build/reports/tests"
@@ -61,12 +61,12 @@ jobs:
 
     name: '[${{ matrix.os }}] Gradle: ${{ matrix.gradle }}, Java: ${{ matrix.java }}'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Set up JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: 'adopt'
           java-version: ${{ matrix.java }}
@@ -123,12 +123,12 @@ jobs:
 
     name: '[android] Gradle: ${{ matrix.gradle }}, Java: ${{ matrix.java }}, AGP: ${{ matrix.agp }}'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Set up JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: 'adopt'
           java-version: ${{ matrix.java }}

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -24,7 +24,7 @@ jobs:
           java-version: 17
 
       - name: Gradle wrapper validation
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/wrapper-validation-action@859c33240bd026ce8d5f711f5adcc65c2f8eafc1 # https://github.com/gradle/wrapper-validation-action/issues/66
 
       - name: ./gradlew assemble
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,10 @@ jobs:
     name: Publish plugin
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: 'adopt'
           java-version: 17

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,7 +68,7 @@ dependencies {
 
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${Versions.junit}")
     testImplementation("org.junit.jupiter:junit-jupiter-api:${Versions.junit}")
-    implementation("commons-io:commons-io:2.11.0")
+    testImplementation("commons-io:commons-io:2.11.0")
     testImplementation("org.mockito.kotlin:mockito-kotlin:${Versions.mockitoKotlin}")
 }
 


### PR DESCRIPTION
Inspired by the number of warnings in: https://github.com/jeremymailen/kotlinter-gradle/actions/runs/3304708014 - this is my attempt to address them

<img width="466" alt="image" src="https://user-images.githubusercontent.com/36954793/197363378-013fef67-ed30-4665-a9e7-ab1541090c86.png">
