### PR TITLE
doc: Fix ktlint document URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Kotlinter will configure itself using an `.editorconfig` file if one is present.
 
 This configuration includes code style and linting rules.
 
-See [KtLint configuration](https://pinterest.github.io/ktlint/rules/configuration-ktlint/) for details.
+See [KtLint configuration](https://pinterest.github.io/ktlint/latest/rules/configuration-ktlint/) for details.
 
 ### Customizing Tasks
 


### PR DESCRIPTION
This PR fixes 404 of a link to KtLint document website.

It is now published for multiple versions.
https://pinterest.github.io/ktlint/latest/rules/configuration-ktlint/ redirects to
https://pinterest.github.io/ktlint/0.50.0/rules/configuration-ktlint/ at this moment.
