### PR TITLE
Update ktlint to 1.0.1 to enable support for composable functions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,7 @@ description = projectDescription
 object Versions {
     const val androidTools = "7.3.1"
     const val junit = "5.9.3"
-    const val ktlint = "1.0.0"
+    const val ktlint = "1.0.1"
     const val mockitoKotlin = "4.1.0"
 }
 

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterPlugin.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterPlugin.kt
@@ -99,4 +99,4 @@ class KotlinterPlugin : Plugin<Project> {
 internal val String.id: String
     get() = split(" ").first()
 
-internal fun Project.reportFile(name: String): File = file("$buildDir/reports/ktlint/$name")
+internal fun Project.reportFile(name: String): File = file("${layout.buildDirectory}/reports/ktlint/$name")


### PR DESCRIPTION
Starting with ktlint version 1.0.1 it supports Composable functions by using the flag `ktlint_function_naming_ignore_when_annotated_with=Composable`. This tremendously helps modern Android projects to avoid custom rules for the naming guidelines for Composable functions.