### PR TITLE
Fix Lint and Format Tasks not re-running after editorconfig changes

### DIFF
--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/ConfigurableKtLintTask.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/ConfigurableKtLintTask.kt
@@ -28,11 +28,8 @@ abstract class ConfigurableKtLintTask(
         from(projectLayout.findApplicableEditorConfigFiles().toList())
     }
 
-    protected fun getChangedEditorconfigFiles(inputChanges: InputChanges) = if (inputChanges.isIncremental) {
+    protected fun getChangedEditorconfigFiles(inputChanges: InputChanges) =
         inputChanges.getFileChanges(editorconfigFiles).map(FileChange::getFile)
-    } else {
-        emptyList()
-    }
 }
 
 internal inline fun <reified T> ObjectFactory.property(default: T? = null): Property<T> = property(T::class.java).apply {


### PR DESCRIPTION
Fixes #327

h/t @mateuszkwiecinski for figuring this one out.

After a build failure, logic before did not check for changed editorconfig files since that scenario is not "incremental".
Instead we always return changed editorconfig files.

Update tests accordingly.