### PR TITLE
Run Kotlinter in process isolation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ val githubUrl = "https://github.com/jeremymailen/kotlinter-gradle"
 val webUrl = "https://github.com/jeremymailen/kotlinter-gradle"
 val projectDescription = "Lint and formatting for Kotlin using ktlint with configuration-free setup on JVM and Android projects"
 
-version = "4.5.0"
+version = "5.0.0-M1"
 group = "org.jmailen.gradle"
 description = projectDescription
 
@@ -46,10 +46,13 @@ dependencies {
     compileOnly("org.jetbrains.kotlin:kotlin-gradle-plugin")
     compileOnly(libs.android.tools.gradle)
 
-    implementation(libs.bundles.ktlint.engine)
-    implementation(libs.bundles.ktlint.reporters)
-    implementation(libs.bundles.ktlint.rulesets)
+    compileOnly(libs.bundles.ktlint.engine)
+    compileOnly(libs.bundles.ktlint.reporters)
+    compileOnly(libs.bundles.ktlint.rulesets)
 
+    testImplementation(libs.bundles.ktlint.engine)
+    testImplementation(libs.bundles.ktlint.reporters)
+    testImplementation(libs.bundles.ktlint.rulesets)
     testImplementation(libs.bundles.junit.jupiter)
     testImplementation(libs.commons.io)
     testImplementation(libs.mockito.kotlin)
@@ -67,7 +70,12 @@ tasks {
         outputs.file(propertiesFile)
 
         doLast {
-            propertiesFile.writeText("version = $projectVersion")
+            propertiesFile.writeText(
+                """
+                version = $projectVersion
+                ktlintVersion = ${libs.versions.ktlint.get()}
+                """.trimIndent()
+            )
         }
     }
 

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterExtension.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterExtension.kt
@@ -5,13 +5,13 @@ import org.jmailen.gradle.kotlinter.support.versionProperties
 
 open class KotlinterExtension {
     companion object {
-        const val DEFAULT_FAIL_BUILD_WHEN_CANNOT_AUTO_FORMAT = false
-        const val DEFAULT_IGNORE_FAILURES = false
+        const val DEFAULT_IGNORE_FORMAT_FAILURES = true
+        const val DEFAULT_IGNORE_LINT_FAILURES = false
         val DEFAULT_REPORTER = ReporterType.checkstyle.name
     }
 
     var ktlintVersion = versionProperties.ktlintVersion()
-    var failBuildWhenCannotAutoFormat = DEFAULT_FAIL_BUILD_WHEN_CANNOT_AUTO_FORMAT
-    var ignoreFailures = DEFAULT_IGNORE_FAILURES
+    var ignoreFormatFailures = DEFAULT_IGNORE_FORMAT_FAILURES
+    var ignoreLintFailures = DEFAULT_IGNORE_LINT_FAILURES
     var reporters = arrayOf(DEFAULT_REPORTER)
 }

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterExtension.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterExtension.kt
@@ -1,6 +1,7 @@
 package org.jmailen.gradle.kotlinter
 
 import org.jmailen.gradle.kotlinter.support.ReporterType
+import org.jmailen.gradle.kotlinter.support.versionProperties
 
 open class KotlinterExtension {
     companion object {
@@ -9,6 +10,7 @@ open class KotlinterExtension {
         val DEFAULT_REPORTER = ReporterType.checkstyle.name
     }
 
+    var ktlintVersion = versionProperties.ktlintVersion()
     var failBuildWhenCannotAutoFormat = DEFAULT_FAIL_BUILD_WHEN_CANNOT_AUTO_FORMAT
     var ignoreFailures = DEFAULT_IGNORE_FAILURES
     var reporters = arrayOf(DEFAULT_REPORTER)

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterPlugin.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterPlugin.kt
@@ -1,6 +1,5 @@
 package org.jmailen.gradle.kotlinter
 
-import com.pinterest.ktlint.cli.reporter.core.api.ktlintVersion
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -92,7 +91,7 @@ class KotlinterPlugin : Plugin<Project> {
                 LintTask::class.java,
             ) { lintTask ->
                 lintTask.source(resolvedSources)
-                lintTask.ignoreFailures.set(provider { kotlinterExtension.ignoreFailures })
+                lintTask.ignoreLintFailures.set(provider { kotlinterExtension.ignoreLintFailures })
                 lintTask.reports.set(
                     provider {
                         kotlinterExtension.reporters.associateWith { reporter ->
@@ -110,8 +109,8 @@ class KotlinterPlugin : Plugin<Project> {
                 FormatTask::class.java,
             ) { formatTask ->
                 formatTask.source(resolvedSources)
-                formatTask.failBuildWhenCannotAutoFormat.set(provider { kotlinterExtension.failBuildWhenCannotAutoFormat })
-                formatTask.ignoreFailures.set(provider { kotlinterExtension.ignoreFailures })
+                formatTask.ignoreFormatFailures.set(provider { kotlinterExtension.ignoreFormatFailures })
+                formatTask.ignoreLintFailures.set(provider { kotlinterExtension.ignoreLintFailures })
                 formatTask.report.set(reportFile("$id-format.txt"))
             }
             parentFormatTask.configure { formatTask ->

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/support/VersionProperties.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/support/VersionProperties.kt
@@ -2,10 +2,14 @@ package org.jmailen.gradle.kotlinter.support
 
 import java.util.Properties
 
+val versionProperties by lazy { VersionProperties() }
+
 class VersionProperties : Properties() {
     init {
         load(this.javaClass.getResourceAsStream("/version.properties"))
     }
 
     fun version(): String = getProperty("version")
+
+    fun ktlintVersion(): String = getProperty("ktlintVersion")
 }

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/ConfigurableKtLintTask.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/ConfigurableKtLintTask.kt
@@ -1,11 +1,13 @@
 package org.jmailen.gradle.kotlinter.tasks
 
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.PathSensitive
@@ -29,6 +31,9 @@ abstract class ConfigurableKtLintTask(projectLayout: ProjectLayout, objectFactor
 
     @Input
     open val ignoreFailures: Property<Boolean> = objectFactory.property(default = DEFAULT_IGNORE_FAILURES)
+
+    @Classpath
+    val ktlintClasspath: ConfigurableFileCollection = objectFactory.fileCollection()
 
     protected fun getChangedEditorconfigFiles(inputChanges: InputChanges) =
         inputChanges.getFileChanges(editorconfigFiles).map(FileChange::getFile)

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/ConfigurableKtLintTask.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/ConfigurableKtLintTask.kt
@@ -13,11 +13,11 @@ import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.SourceTask
-import org.gradle.internal.exceptions.MultiCauseException
 import org.gradle.work.FileChange
 import org.gradle.work.Incremental
 import org.gradle.work.InputChanges
-import org.jmailen.gradle.kotlinter.KotlinterExtension.Companion.DEFAULT_IGNORE_FAILURES
+import org.gradle.workers.WorkerExecutionException
+import org.jmailen.gradle.kotlinter.KotlinterExtension.Companion.DEFAULT_IGNORE_LINT_FAILURES
 import org.jmailen.gradle.kotlinter.support.findApplicableEditorConfigFiles
 
 abstract class ConfigurableKtLintTask(projectLayout: ProjectLayout, objectFactory: ObjectFactory) : SourceTask() {
@@ -30,7 +30,7 @@ abstract class ConfigurableKtLintTask(projectLayout: ProjectLayout, objectFactor
     }
 
     @Input
-    open val ignoreFailures: Property<Boolean> = objectFactory.property(default = DEFAULT_IGNORE_FAILURES)
+    open val ignoreLintFailures: Property<Boolean> = objectFactory.property(default = DEFAULT_IGNORE_LINT_FAILURES)
 
     @Classpath
     val ktlintClasspath: ConfigurableFileCollection = objectFactory.fileCollection()
@@ -53,10 +53,8 @@ internal inline fun <reified K, reified V> ObjectFactory.mapProperty(default: Ma
         set(default)
     }
 
-inline fun <reified T : Throwable> Throwable.workErrorCauses(): List<Throwable> = when (this) {
-    is MultiCauseException -> this.causes.map { it.cause }
-    else -> listOf(this.cause)
-}.filter {
-    // class instance comparison doesn't work due to different classloaders
-    it?.javaClass?.canonicalName == T::class.java.canonicalName
-}.filterNotNull()
+fun WorkerExecutionException.hasRootCause(type: Class<*>): Boolean {
+    // this is lame, but serialized across worker boundaries exceptions are not comparable
+    // and recursive cause checking runs into serialized placeholder exceptions
+    return this.stackTraceToString().contains(type.canonicalName)
+}

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/FormatTask.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/FormatTask.kt
@@ -1,6 +1,5 @@
 package org.jmailen.gradle.kotlinter.tasks
 
-import org.gradle.api.GradleException
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
@@ -10,10 +9,9 @@ import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import org.gradle.work.InputChanges
+import org.gradle.workers.WorkerExecutionException
 import org.gradle.workers.WorkerExecutor
-import org.jetbrains.kotlin.utils.addToStdlib.ifNotEmpty
 import org.jmailen.gradle.kotlinter.KotlinterExtension
-import org.jmailen.gradle.kotlinter.support.KotlinterError
 import org.jmailen.gradle.kotlinter.support.LintFailure
 import org.jmailen.gradle.kotlinter.tasks.format.FormatWorkerAction
 import javax.inject.Inject
@@ -32,8 +30,8 @@ open class FormatTask @Inject constructor(
     val report: RegularFileProperty = objectFactory.fileProperty()
 
     @Input
-    val failBuildWhenCannotAutoFormat: Property<Boolean> = objectFactory.property(
-        default = KotlinterExtension.DEFAULT_FAIL_BUILD_WHEN_CANNOT_AUTO_FORMAT,
+    val ignoreFormatFailures: Property<Boolean> = objectFactory.property(
+        default = KotlinterExtension.DEFAULT_IGNORE_FORMAT_FAILURES,
     )
 
     init {
@@ -42,29 +40,25 @@ open class FormatTask @Inject constructor(
 
     @TaskAction
     fun run(inputChanges: InputChanges) {
-        val workQueue = workerExecutor.classLoaderIsolation { config ->
+        val workQueue = workerExecutor.processIsolation { config ->
             config.classpath.setFrom(ktlintClasspath)
         }
-        val result = with(workQueue) {
-            submit(FormatWorkerAction::class.java) { p ->
-                p.name.set(name)
-                p.files.from(source)
-                p.projectDirectory.set(projectLayout.projectDirectory.asFile)
-                p.output.set(report)
-                p.changedEditorConfigFiles.from(getChangedEditorconfigFiles(inputChanges))
-            }
-            runCatching { await() }
+        workQueue.submit(FormatWorkerAction::class.java) { p ->
+            p.name.set(name)
+            p.files.from(source)
+            p.projectDirectory.set(projectLayout.projectDirectory.asFile)
+            p.output.set(report)
+            p.changedEditorConfigFiles.from(getChangedEditorconfigFiles(inputChanges))
         }
-
-        result.exceptionOrNull()?.workErrorCauses<KotlinterError>()?.ifNotEmpty {
-            forEach { logger.error(it.message, it.cause) }
-            throw GradleException("error formatting sources for $name")
-        }
-
-        if (failBuildWhenCannotAutoFormat.get()) {
-            val lintFailures = result.exceptionOrNull()?.workErrorCauses<LintFailure>() ?: emptyList()
-            if (lintFailures.isNotEmpty() && !ignoreFailures.get()) {
-                throw GradleException("$name sources failed lint check")
+        try {
+            workQueue.await()
+        } catch (e: WorkerExecutionException) {
+            if (e.hasRootCause(LintFailure::class.java)) {
+                if (!ignoreFormatFailures.get()) {
+                    throw e
+                }
+            } else {
+                throw e
             }
         }
     }

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/FormatTask.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/FormatTask.kt
@@ -42,7 +42,10 @@ open class FormatTask @Inject constructor(
 
     @TaskAction
     fun run(inputChanges: InputChanges) {
-        val result = with(workerExecutor.noIsolation()) {
+        val workQueue = workerExecutor.classLoaderIsolation { config ->
+            config.classpath.setFrom(ktlintClasspath)
+        }
+        val result = with(workQueue) {
             submit(FormatWorkerAction::class.java) { p ->
                 p.name.set(name)
                 p.files.from(source)

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/GitHookTasks.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/GitHookTasks.kt
@@ -5,7 +5,7 @@ import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
-import org.jmailen.gradle.kotlinter.support.VersionProperties
+import org.jmailen.gradle.kotlinter.support.versionProperties
 import java.io.File
 
 abstract class InstallPreCommitHookTask : InstallHookTask("pre-commit") {
@@ -111,11 +111,9 @@ abstract class InstallHookTask(@get:Internal val hookFileName: String) : Default
     }
 
     companion object {
-        private val version = VersionProperties().version()
-
         internal const val START_HOOK = "\n##### KOTLINTER HOOK START #####"
 
-        internal val hookVersion = "##### KOTLINTER $version #####"
+        internal val hookVersion = "##### KOTLINTER ${versionProperties.version()} #####"
 
         internal const val END_HOOK = "##### KOTLINTER HOOK END #####\n"
 

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/LintTask.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/LintTask.kt
@@ -39,7 +39,10 @@ open class LintTask @Inject constructor(
 
     @TaskAction
     fun run(inputChanges: InputChanges) {
-        val result = with(workerExecutor.noIsolation()) {
+        val workQueue = workerExecutor.classLoaderIsolation { config ->
+            config.classpath.setFrom(ktlintClasspath)
+        }
+        val result = with(workQueue) {
             submit(LintWorkerAction::class.java) { p ->
                 p.name.set(name)
                 p.files.from(source)

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/LintTask.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/LintTask.kt
@@ -1,6 +1,5 @@
 package org.jmailen.gradle.kotlinter.tasks
 
-import org.gradle.api.GradleException
 import org.gradle.api.file.FileTree
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.model.ObjectFactory
@@ -12,9 +11,8 @@ import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.work.InputChanges
+import org.gradle.workers.WorkerExecutionException
 import org.gradle.workers.WorkerExecutor
-import org.jetbrains.kotlin.utils.addToStdlib.ifNotEmpty
-import org.jmailen.gradle.kotlinter.support.KotlinterError
 import org.jmailen.gradle.kotlinter.support.LintFailure
 import org.jmailen.gradle.kotlinter.tasks.lint.LintWorkerAction
 import java.io.File
@@ -39,28 +37,22 @@ open class LintTask @Inject constructor(
 
     @TaskAction
     fun run(inputChanges: InputChanges) {
-        val workQueue = workerExecutor.classLoaderIsolation { config ->
+        val workQueue = workerExecutor.processIsolation { config ->
             config.classpath.setFrom(ktlintClasspath)
         }
-        val result = with(workQueue) {
-            submit(LintWorkerAction::class.java) { p ->
-                p.name.set(name)
-                p.files.from(source)
-                p.projectDirectory.set(projectLayout.projectDirectory.asFile)
-                p.reporters.putAll(reports)
-                p.changedEditorConfigFiles.from(getChangedEditorconfigFiles(inputChanges))
+        workQueue.submit(LintWorkerAction::class.java) { p ->
+            p.name.set(name)
+            p.files.from(source)
+            p.projectDirectory.set(projectLayout.projectDirectory.asFile)
+            p.reporters.putAll(reports)
+            p.changedEditorConfigFiles.from(getChangedEditorconfigFiles(inputChanges))
+        }
+        try {
+            workQueue.await()
+        } catch (e: WorkerExecutionException) {
+            if (!(ignoreLintFailures.get() && e.hasRootCause(LintFailure::class.java))) {
+                throw e
             }
-            runCatching { await() }
-        }
-
-        result.exceptionOrNull()?.workErrorCauses<KotlinterError>()?.ifNotEmpty {
-            forEach { logger.error(it.message, it.cause) }
-            throw GradleException("error linting sources for $name")
-        }
-
-        val lintFailures = result.exceptionOrNull()?.workErrorCauses<LintFailure>() ?: emptyList()
-        if (lintFailures.isNotEmpty() && !ignoreFailures.get()) {
-            throw GradleException("$name sources failed lint check")
         }
     }
 }

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/format/FormatWorkerAction.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/format/FormatWorkerAction.kt
@@ -64,7 +64,7 @@ abstract class FormatWorkerAction : WorkAction<FormatWorkerParameters> {
         }
 
         if (hasError) {
-            throw LintFailure("kotlin source failed lint check")
+            throw LintFailure("kotlin source $name failed lint check")
         }
 
         output?.writeText(

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/lint/LintWorkerAction.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/lint/LintWorkerAction.kt
@@ -63,7 +63,7 @@ abstract class LintWorkerAction : WorkAction<LintWorkerParameters> {
         }
 
         if (hasError) {
-            throw LintFailure("kotlin source failed lint check")
+            throw LintFailure("kotlin source $name failed lint check")
         }
     }
 }

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/CustomTaskTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/CustomTaskTest.kt
@@ -112,7 +112,7 @@ class CustomTaskTest : WithGradleTest.Kotlin() {
                 task customizedLintTask(type: LintTask) {
                     source files('src')
                     reports = ['plain': file('build/lint-report.txt')]
-                    ignoreFailures = true
+                    ignoreLintFailures = true
                 }
                 
                 """.trimIndent()

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/CustomTaskTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/CustomTaskTest.kt
@@ -3,6 +3,7 @@ package org.jmailen.gradle.kotlinter.functional
 import org.gradle.testkit.runner.TaskOutcome
 import org.jmailen.gradle.kotlinter.functional.utils.editorConfig
 import org.jmailen.gradle.kotlinter.functional.utils.kotlinClass
+import org.jmailen.gradle.kotlinter.functional.utils.repositories
 import org.jmailen.gradle.kotlinter.functional.utils.resolve
 import org.jmailen.gradle.kotlinter.functional.utils.settingsFile
 import org.junit.jupiter.api.Assertions.assertArrayEquals
@@ -28,7 +29,7 @@ class CustomTaskTest : WithGradleTest.Kotlin() {
                         id 'kotlin'
                         id 'org.jmailen.kotlinter'
                     }
-                
+                    $repositories
                     """.trimIndent()
                 writeText(buildScript)
             }

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/EditorConfigTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/EditorConfigTest.kt
@@ -30,7 +30,7 @@ internal class EditorConfigTest : WithGradleTest.Kotlin() {
                         }
                         $repositories
                         """.trimIndent()
-                    KotlinterConfig.FAIL_BUILD_WHEN_CANNOT_AUTO_FORMAT ->
+                    KotlinterConfig.FAIL_FORMAT_FAILURES ->
                         """
                         plugins {
                             id 'org.jetbrains.kotlin.js'
@@ -45,10 +45,10 @@ internal class EditorConfigTest : WithGradleTest.Kotlin() {
                         }
 
                         kotlinter {
-                            failBuildWhenCannotAutoFormat = true
+                            ignoreFormatFailures = false
                         }
                         """.trimIndent()
-                    KotlinterConfig.IGNORE_FAILURES ->
+                    KotlinterConfig.IGNORE_LINT_FAILURES ->
                         """
                         plugins {
                             id 'org.jetbrains.kotlin.js'
@@ -63,8 +63,7 @@ internal class EditorConfigTest : WithGradleTest.Kotlin() {
                         }
 
                         kotlinter {
-                            ignoreFailures = true
-                            failBuildWhenCannotAutoFormat = true
+                            ignoreLintFailures = true
                         }
                         """.trimIndent()
                 }
@@ -250,8 +249,8 @@ internal class EditorConfigTest : WithGradleTest.Kotlin() {
     }
 
     @Test
-    fun `editorconfig changes are taken for format task re-runs when failBuildWhenCannotAutoFormat configured`() {
-        setup(KotlinterConfig.FAIL_BUILD_WHEN_CANNOT_AUTO_FORMAT)
+    fun `editorconfig changes are taken for format task re-runs when ignoreFormatFailures false`() {
+        setup(KotlinterConfig.FAIL_FORMAT_FAILURES)
         projectRoot.resolve(".editorconfig") {
             writeText(editorConfig)
         }

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/EditorConfigTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/EditorConfigTest.kt
@@ -4,6 +4,7 @@ import org.gradle.testkit.runner.TaskOutcome
 import org.jmailen.gradle.kotlinter.functional.utils.KotlinterConfig
 import org.jmailen.gradle.kotlinter.functional.utils.editorConfig
 import org.jmailen.gradle.kotlinter.functional.utils.kotlinClass
+import org.jmailen.gradle.kotlinter.functional.utils.repositories
 import org.jmailen.gradle.kotlinter.functional.utils.resolve
 import org.jmailen.gradle.kotlinter.functional.utils.settingsFile
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -27,6 +28,7 @@ internal class EditorConfigTest : WithGradleTest.Kotlin() {
                             id 'kotlin'
                             id 'org.jmailen.kotlinter'
                         }
+                        $repositories
                         """.trimIndent()
                     KotlinterConfig.FAIL_BUILD_WHEN_CANNOT_AUTO_FORMAT ->
                         """
@@ -34,6 +36,7 @@ internal class EditorConfigTest : WithGradleTest.Kotlin() {
                             id 'org.jetbrains.kotlin.js'
                             id 'org.jmailen.kotlinter'
                         }
+                        $repositories
 
                         kotlin {
                             js {
@@ -51,6 +54,7 @@ internal class EditorConfigTest : WithGradleTest.Kotlin() {
                             id 'org.jetbrains.kotlin.js'
                             id 'org.jmailen.kotlinter'
                         }
+                        $repositories
 
                         kotlin {
                             js {

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/ExtensionTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/ExtensionTest.kt
@@ -2,6 +2,7 @@ package org.jmailen.gradle.kotlinter.functional
 
 import org.gradle.testkit.runner.TaskOutcome
 import org.jmailen.gradle.kotlinter.functional.utils.kotlinClass
+import org.jmailen.gradle.kotlinter.functional.utils.repositories
 import org.jmailen.gradle.kotlinter.functional.utils.resolve
 import org.jmailen.gradle.kotlinter.functional.utils.settingsFile
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -22,11 +23,11 @@ internal class ExtensionTest : WithGradleTest.Kotlin() {
                 // language=groovy
                 val buildScript =
                     """
-                plugins {
-                    id 'kotlin'
-                    id 'org.jmailen.kotlinter'
-                }
-                
+                    plugins {
+                        id 'kotlin'
+                        id 'org.jmailen.kotlinter'
+                    }
+                    $repositories
                     """.trimIndent()
                 writeText(buildScript)
             }
@@ -87,6 +88,7 @@ internal class ExtensionTest : WithGradleTest.Kotlin() {
                     id 'kotlin'
                     id 'org.jmailen.kotlinter'
                 }
+                $repositories
                 
                 tasks.whenTaskAdded {
                     // configure all tasks eagerly

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/ExtensionTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/ExtensionTest.kt
@@ -35,13 +35,13 @@ internal class ExtensionTest : WithGradleTest.Kotlin() {
     }
 
     @Test
-    fun `extension configures ignoreFailures`() {
+    fun `extension configures ignoreLintFailures`() {
         projectRoot.resolve("build.gradle") {
             // language=groovy
             val script =
                 """
                 kotlinter {
-                    ignoreFailures = true
+                    ignoreLintFailures = true
                 }
                 """.trimIndent()
             appendText(script)
@@ -95,7 +95,7 @@ internal class ExtensionTest : WithGradleTest.Kotlin() {
                 }
                 
                 kotlinter {
-                    ignoreFailures = true
+                    ignoreLintFailures = true
                 }
                 
                 """.trimIndent()

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/KotlinJsProjectTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/KotlinJsProjectTest.kt
@@ -33,7 +33,7 @@ class KotlinJsProjectTest : WithGradleTest.Kotlin() {
                             }
                         }
                         """.trimIndent()
-                    KotlinterConfig.FAIL_BUILD_WHEN_CANNOT_AUTO_FORMAT ->
+                    KotlinterConfig.FAIL_FORMAT_FAILURES ->
                         """
                         plugins {
                             id 'org.jetbrains.kotlin.js'
@@ -50,10 +50,10 @@ class KotlinJsProjectTest : WithGradleTest.Kotlin() {
                         }
                         
                         kotlinter {
-                            failBuildWhenCannotAutoFormat = true
+                            ignoreFormatFailures = false
                         }
                         """.trimIndent()
-                    KotlinterConfig.IGNORE_FAILURES ->
+                    KotlinterConfig.IGNORE_LINT_FAILURES ->
                         """
                         plugins {
                             id 'org.jetbrains.kotlin.js'
@@ -70,8 +70,7 @@ class KotlinJsProjectTest : WithGradleTest.Kotlin() {
                         }
                         
                         kotlinter {
-                            ignoreFailures = true
-                            failBuildWhenCannotAutoFormat = true
+                            ignoreLintFailures = true
                         }
                         """.trimIndent()
                 }
@@ -160,8 +159,8 @@ class KotlinJsProjectTest : WithGradleTest.Kotlin() {
     }
 
     @Test
-    fun `formatKotlin fails when lint errors not automatically fixed and failBuildWhenCannotAutoFormat enabled`() {
-        setup(KotlinterConfig.FAIL_BUILD_WHEN_CANNOT_AUTO_FORMAT)
+    fun `formatKotlin fails when lint errors not automatically fixed and ignoreFormatFailures false`() {
+        setup(KotlinterConfig.FAIL_FORMAT_FAILURES)
         projectRoot.resolve("src/main/kotlin/FixtureClass.kt") {
             // language=kotlin
             val kotlinClass =
@@ -195,47 +194,6 @@ class KotlinJsProjectTest : WithGradleTest.Kotlin() {
             assertTrue(output.contains("FixtureClass.kt:3:19: Format fixed > [standard:curly-spacing] Missing spacing before \"{\""))
             assertTrue(output.contains("FixtureClass.kt:1:1: Format could not fix > [standard:no-wildcard-imports] Wildcard import"))
             assertEquals(TaskOutcome.FAILED, task(":formatKotlinTest")?.outcome)
-            assertTrue(output.contains("FixtureTestClass.kt:3:23: Format fixed > [standard:curly-spacing] Missing spacing before \"{\""))
-            assertTrue(output.contains("FixtureTestClass.kt:1:1: Format could not fix > [standard:no-wildcard-imports] Wildcard import"))
-        }
-    }
-
-    @Test
-    fun `formatKotlin reports formatted and unformatted files when failBuildWhenCannotAutoFormat and ignoreFailures enabled`() {
-        setup(KotlinterConfig.IGNORE_FAILURES)
-        projectRoot.resolve("src/main/kotlin/FixtureClass.kt") {
-            // language=kotlin
-            val kotlinClass =
-                """
-                import System.*
-                
-                class FixtureClass{
-                    private fun hi() {
-                        out.println("Hello")
-                    }
-                }
-                """.trimIndent()
-            writeText(kotlinClass)
-        }
-        projectRoot.resolve("src/test/kotlin/FixtureTestClass.kt") {
-            // language=kotlin
-            val kotlinClass =
-                """
-                import System.*
-                
-                class FixtureTestClass{
-                    private fun hi() {
-                        out.println("Hello")
-                    }
-                }
-                """.trimIndent()
-            writeText(kotlinClass)
-        }
-        build("formatKotlin").apply {
-            assertEquals(TaskOutcome.SUCCESS, task(":formatKotlinMain")?.outcome)
-            assertTrue(output.contains("FixtureClass.kt:3:19: Format fixed > [standard:curly-spacing] Missing spacing before \"{\""))
-            assertTrue(output.contains("FixtureClass.kt:1:1: Format could not fix > [standard:no-wildcard-imports] Wildcard import"))
-            assertEquals(TaskOutcome.SUCCESS, task(":formatKotlinTest")?.outcome)
             assertTrue(output.contains("FixtureTestClass.kt:3:23: Format fixed > [standard:curly-spacing] Missing spacing before \"{\""))
             assertTrue(output.contains("FixtureTestClass.kt:1:1: Format could not fix > [standard:no-wildcard-imports] Wildcard import"))
         }

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/KotlinProjectTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/KotlinProjectTest.kt
@@ -103,9 +103,9 @@ internal class KotlinProjectTest : WithGradleTest.Kotlin() {
     }
 
     @Test
-    fun `formatKotlin fails when lint errors not automatically fixed and failBuildWhenCannotAutoFormat enabled`() {
+    fun `formatKotlin fails when lint errors not automatically fixed and ignoreFormatFailures false`() {
         settingsFile()
-        buildFileFailBuildWhenCannotAutoFormat()
+        buildFileIgnoreFormatFailuresFalse()
         // language=kotlin
         val kotlinClass =
             """
@@ -121,32 +121,6 @@ internal class KotlinProjectTest : WithGradleTest.Kotlin() {
 
         buildAndFail("formatKotlin").apply {
             assertEquals(FAILED, task(":formatKotlinMain")?.outcome)
-            output.lines().filter { it.contains("Format could not fix") }.forEach { line ->
-                val filePath = pathPattern.find(line)?.groups?.get(1)?.value.orEmpty()
-                assertTrue(File(filePath).exists())
-            }
-        }
-    }
-
-    @Test
-    fun `formatKotlin reports formatted and unformatted files when failBuildWhenCannotAutoFormat and ignoreFailures enabled`() {
-        settingsFile()
-        buildFileIgnoreFailures()
-        // language=kotlin
-        val kotlinClass =
-            """
-            import System.*
-            
-            class KotlinClass{
-                private fun hi() {
-                    out.println("Hello")
-                }
-            }
-            """.trimIndent()
-        kotlinSourceFile("KotlinClass.kt", kotlinClass)
-
-        build("formatKotlin").apply {
-            assertEquals(SUCCESS, task(":formatKotlinMain")?.outcome)
             output.lines().filter { it.contains("Format could not fix") }.forEach { line ->
                 val filePath = pathPattern.find(line)?.groups?.get(1)?.value.orEmpty()
                 assertTrue(File(filePath).exists())
@@ -262,7 +236,7 @@ internal class KotlinProjectTest : WithGradleTest.Kotlin() {
         writeText(buildscript)
     }
 
-    private fun buildFileFailBuildWhenCannotAutoFormat() = buildFile.apply {
+    private fun buildFileIgnoreFormatFailuresFalse() = buildFile.apply {
         // language=groovy
         val buildscript =
             """
@@ -276,28 +250,7 @@ internal class KotlinProjectTest : WithGradleTest.Kotlin() {
             }
             
             kotlinter {
-                failBuildWhenCannotAutoFormat = true
-            }
-            """.trimIndent()
-        writeText(buildscript)
-    }
-
-    private fun buildFileIgnoreFailures() = buildFile.apply {
-        // language=groovy
-        val buildscript =
-            """
-            plugins {
-                id 'org.jetbrains.kotlin.jvm'
-                id 'org.jmailen.kotlinter'
-            }
-
-            repositories {
-                mavenCentral()
-            }
-            
-            kotlinter {
-                ignoreFailures = true
-                failBuildWhenCannotAutoFormat = true
+                ignoreFormatFailures = false
             }
             """.trimIndent()
         writeText(buildscript)

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/utils/Factories.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/utils/Factories.kt
@@ -25,3 +25,11 @@ internal val editorConfig =
     [*.kt]
     
     """
+
+internal val repositories =
+    """
+    repositories {
+        mavenCentral()
+    }
+
+    """.trimIndent()

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/utils/KotlinterConfig.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/utils/KotlinterConfig.kt
@@ -2,6 +2,6 @@ package org.jmailen.gradle.kotlinter.functional.utils
 
 enum class KotlinterConfig {
     DEFAULT,
-    FAIL_BUILD_WHEN_CANNOT_AUTO_FORMAT,
-    IGNORE_FAILURES,
+    FAIL_FORMAT_FAILURES,
+    IGNORE_LINT_FAILURES,
 }


### PR DESCRIPTION
First in a series of changes leading to a 5.0.0 release. Starting with Kotlin 2.1.0 it's no longer acceptable to run ktlint and the embedded Kotlin compiler in the main Gradle classloader. The solution is to use Gradle worker process isolation.

Positive consequences:
- Users can configure the version of ktlint
- Kotlinter is compatible with any version of Kotlin with matching language specification

Side effects to watch:
- Performance may be slower