### PR TITLE
Load ktlint dependency always when Kotlinter applied

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Available on the Gradle Plugins Portal: https://plugins.gradle.org/plugin/org.jm
 
 ```kotlin
 plugins {
-    id("org.jmailen.kotlinter") version "5.0.0"
+    id("org.jmailen.kotlinter") version "5.0.1"
 }
 ```
 
@@ -36,7 +36,7 @@ plugins {
 
 ```groovy
 plugins {
-    id "org.jmailen.kotlinter" version "5.0.0"
+    id "org.jmailen.kotlinter" version "5.0.1"
 }
 ```
 
@@ -50,7 +50,7 @@ Root `build.gradle.kts`
 
 ```kotlin
 plugins {
-    id("org.jmailen.kotlinter") version "5.0.0" apply false
+    id("org.jmailen.kotlinter") version "5.0.1" apply false
 }
 ```
 
@@ -70,7 +70,7 @@ Root `build.gradle`
 
 ```groovy
 plugins {
-    id 'org.jmailen.kotlinter' version "5.0.0" apply false
+    id 'org.jmailen.kotlinter' version "5.0.1" apply false
 }
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ val githubUrl = "https://github.com/jeremymailen/kotlinter-gradle"
 val webUrl = "https://github.com/jeremymailen/kotlinter-gradle"
 val projectDescription = "Lint and formatting for Kotlin using ktlint with configuration-free setup on JVM and Android projects"
 
-version = "5.0.0"
+version = "5.0.1"
 group = "org.jmailen.gradle"
 description = projectDescription
 

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterPlugin.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterPlugin.kt
@@ -29,6 +29,7 @@ class KotlinterPlugin : Plugin<Project> {
 
     override fun apply(project: Project) = with(project) {
         val kotlinterExtension = extensions.create("kotlinter", KotlinterExtension::class.java)
+        val ktlintConfiguration = createKtLintConfiguration(kotlinterExtension)
 
         if (this == rootProject) {
             registerPrePushHookTask()
@@ -39,7 +40,6 @@ class KotlinterPlugin : Plugin<Project> {
             pluginManager.withPlugin(pluginId) {
                 val lintKotlin = registerParentLintTask()
                 val formatKotlin = registerParentFormatTask()
-                val ktlintConfiguration = createKtLintConfiguration(kotlinterExtension)
 
                 registerSourceSetTasks(kotlinterExtension, sourceResolver, lintKotlin, formatKotlin)
 


### PR DESCRIPTION
Before we only add the dependency configuration when a compatible kotlin plug is detected which doesn't work for projects with only custom kotlinter tasks. Fixes #423