### PR TITLE
WIP: Make KtLint tasks runnable even without specific plugins being present

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Available on the Gradle Plugins Portal: https://plugins.gradle.org/plugin/org.jm
 
 ```kotlin
 plugins {
-    id("org.jmailen.kotlinter") version "5.0.1"
+    id("org.jmailen.kotlinter") version "5.0.2"
 }
 ```
 
@@ -36,7 +36,7 @@ plugins {
 
 ```groovy
 plugins {
-    id "org.jmailen.kotlinter" version "5.0.1"
+    id "org.jmailen.kotlinter" version "5.0.2"
 }
 ```
 
@@ -50,7 +50,7 @@ Root `build.gradle.kts`
 
 ```kotlin
 plugins {
-    id("org.jmailen.kotlinter") version "5.0.1" apply false
+    id("org.jmailen.kotlinter") version "5.0.2" apply false
 }
 ```
 
@@ -70,7 +70,7 @@ Root `build.gradle`
 
 ```groovy
 plugins {
-    id 'org.jmailen.kotlinter' version "5.0.1" apply false
+    id 'org.jmailen.kotlinter' version "5.0.2" apply false
 }
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ val githubUrl = "https://github.com/jeremymailen/kotlinter-gradle"
 val webUrl = "https://github.com/jeremymailen/kotlinter-gradle"
 val projectDescription = "Lint and formatting for Kotlin using ktlint with configuration-free setup on JVM and Android projects"
 
-version = "5.0.1"
+version = "5.0.2"
 group = "org.jmailen.gradle"
 description = projectDescription
 

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterPlugin.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterPlugin.kt
@@ -3,6 +3,7 @@ package org.jmailen.gradle.kotlinter
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.attributes.Bundling
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Provider
@@ -42,12 +43,12 @@ class KotlinterPlugin : Plugin<Project> {
                 val formatKotlin = registerParentFormatTask()
 
                 registerSourceSetTasks(kotlinterExtension, sourceResolver, lintKotlin, formatKotlin)
-
-                // Configure all tasks including custom user tasks
-                tasks.withType(ConfigurableKtLintTask::class.java).configureEach { task ->
-                    task.ktlintClasspath.from(ktlintConfiguration)
-                }
             }
+        }
+
+        // Configure all tasks including custom user tasks
+        tasks.withType(ConfigurableKtLintTask::class.java).configureEach { task ->
+            task.ktlintClasspath.from(ktlintConfiguration)
         }
     }
 
@@ -68,6 +69,8 @@ class KotlinterPlugin : Plugin<Project> {
             isCanBeResolved = true
             isCanBeConsumed = false
             isVisible = false
+
+            attributes.attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling::class.java, Bundling.EXTERNAL))
 
             val dependencyProvider = provider {
                 // Even though we don't use CLI, it bundles all the runtime dependencies we need.

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/CustomTaskTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/CustomTaskTest.kt
@@ -9,28 +9,27 @@ import org.jmailen.gradle.kotlinter.functional.utils.settingsFile
 import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 import java.io.File
 
 class CustomTaskTest : WithGradleTest.Kotlin() {
 
     lateinit var projectRoot: File
 
-    @BeforeEach
-    fun setUp() {
+    private fun setup(testType: String) {
         projectRoot = testProjectDir.apply {
             resolve("settings.gradle") { writeText(settingsFile) }
             resolve("build.gradle") {
-                // language=groovy
-                val buildScript =
-                    """
-                    plugins {
-                        id 'kotlin'
-                        id 'org.jmailen.kotlinter'
+                val buildScript = buildString {
+                    appendLine("plugins {")
+                    if (testType == WITH_KOTLIN_PLUGIN) {
+                        appendLine("id 'kotlin'")
                     }
-                    $repositories
-                    """.trimIndent()
+                    appendLine("id 'org.jmailen.kotlinter'")
+                    appendLine("}")
+                    appendLine(repositories)
+                }
                 writeText(buildScript)
             }
         }
@@ -39,8 +38,11 @@ class CustomTaskTest : WithGradleTest.Kotlin() {
         }
     }
 
-    @Test
-    fun `ktLint custom task succeeds when no lint errors detected`() {
+    @ParameterizedTest
+    @ValueSource(strings = [WITH_NO_PLUGINS, WITH_KOTLIN_PLUGIN])
+    fun `ktLint custom task succeeds when no lint errors detected`(testType: String) {
+        setup(testType)
+
         projectRoot.resolve(".editorconfig") {
             writeText(editorConfig)
         }
@@ -77,8 +79,11 @@ class CustomTaskTest : WithGradleTest.Kotlin() {
         }
     }
 
-    @Test
-    fun `ktLint custom task succeeds with default configuration`() {
+    @ParameterizedTest
+    @ValueSource(strings = [WITH_NO_PLUGINS, WITH_KOTLIN_PLUGIN])
+    fun `ktLint custom task succeeds with default configuration`(testType: String) {
+        setup(testType)
+
         projectRoot.resolve("build.gradle") {
             // language=groovy
             val buildScript =
@@ -98,8 +103,11 @@ class CustomTaskTest : WithGradleTest.Kotlin() {
         }
     }
 
-    @Test
-    fun `ktLint custom task succeeds with fully provided configuration`() {
+    @ParameterizedTest
+    @ValueSource(strings = [WITH_NO_PLUGINS, WITH_KOTLIN_PLUGIN])
+    fun `ktLint custom task succeeds with fully provided configuration`(testType: String) {
+        setup(testType)
+
         projectRoot.resolve(".editorconfig") {
             writeText(editorConfig)
         }
@@ -124,8 +132,11 @@ class CustomTaskTest : WithGradleTest.Kotlin() {
         }
     }
 
-    @Test
-    fun `ktLintFormat custom task succeeds with fully provided configuration`() {
+    @ParameterizedTest
+    @ValueSource(strings = [WITH_NO_PLUGINS, WITH_KOTLIN_PLUGIN])
+    fun `ktLintFormat custom task succeeds with fully provided configuration`(testType: String) {
+        setup(testType)
+
         projectRoot.resolve(".editorconfig") {
             writeText(editorConfig)
         }
@@ -148,8 +159,11 @@ class CustomTaskTest : WithGradleTest.Kotlin() {
         }
     }
 
-    @Test
-    fun `ktLint custom task skips reports generation if reports not configured`() {
+    @ParameterizedTest
+    @ValueSource(strings = [WITH_NO_PLUGINS, WITH_KOTLIN_PLUGIN])
+    fun `ktLint custom task skips reports generation if reports not configured`(testType: String) {
+        setup(testType)
+
         projectRoot.resolve("src/main/kotlin/MissingNewLine.kt") {
             // language=kotlin
             val validClass =
@@ -189,8 +203,11 @@ class CustomTaskTest : WithGradleTest.Kotlin() {
         }
     }
 
-    @Test
-    fun `ktLint custom task became up-to-date on second run if reports not configured`() {
+    @ParameterizedTest
+    @ValueSource(strings = [WITH_NO_PLUGINS, WITH_KOTLIN_PLUGIN])
+    fun `ktLint custom task became up-to-date on second run if reports not configured`(testType: String) {
+        setup(testType)
+
         projectRoot.resolve("build.gradle") {
             // language=groovy
             val buildScript =
@@ -224,8 +241,11 @@ class CustomTaskTest : WithGradleTest.Kotlin() {
         }
     }
 
-    @Test
-    fun `ktLint custom task treats reports as input parameter`() {
+    @ParameterizedTest
+    @ValueSource(strings = [WITH_NO_PLUGINS, WITH_KOTLIN_PLUGIN])
+    fun `ktLint custom task treats reports as input parameter`(testType: String) {
+        setup(testType)
+
         projectRoot.resolve("build.gradle") {
             // language=groovy
             val buildScript =
@@ -255,5 +275,10 @@ class CustomTaskTest : WithGradleTest.Kotlin() {
             assertEquals(TaskOutcome.SUCCESS, task(":ktLintWithReports")?.outcome)
             assertTrue(projectRoot.resolve("build/lint-report.txt").exists())
         }
+    }
+
+    companion object {
+        const val WITH_NO_PLUGINS = "with-no-plugins"
+        const val WITH_KOTLIN_PLUGIN = "with-kotlin-plugin"
     }
 }


### PR DESCRIPTION
Should fix #423, however, when integrated in my codebase I now get a transitive dependency issue:

```
Caused by: java.lang.NoClassDefFoundError: io/github/oshai/kotlinlogging/KotlinLogging
        at com.pinterest.ktlint.ruleset.standard.rules.WrappingRuleKt.<clinit>(WrappingRule.kt:90)
        at com.pinterest.ktlint.ruleset.standard.rules.ArgumentListWrappingRule.<init>(ArgumentListWrappingRule.kt:72)
        at com.pinterest.ktlint.ruleset.standard.StandardRuleSetProvider.getRuleProviders$lambda$2(StandardRuleSetProvider.kt:110)
        at com.pinterest.ktlint.rule.engine.core.api.RuleProvider$Companion.invoke(RuleProvider.kt:41)
        at com.pinterest.ktlint.ruleset.standard.StandardRuleSetProvider.getRuleProviders(StandardRuleSetProvider.kt:110)
        at org.jmailen.gradle.kotlinter.support.RuleSetsKt$resolveRuleProviders$2.invoke(RuleSets.kt:17)
        at org.jmailen.gradle.kotlinter.support.RuleSetsKt$resolveRuleProviders$2.invoke(RuleSets.kt:17)
        at kotlin.sequences.FlatteningSequence$iterator$1.ensureItemIterator(Sequences.kt:330)
        at kotlin.sequences.FlatteningSequence$iterator$1.hasNext(Sequences.kt:318)
        at kotlin.sequences.SequencesKt___SequencesKt.toSet(_Sequences.kt:842)
        at org.jmailen.gradle.kotlinter.support.RuleSetsKt.resolveRuleProviders(RuleSets.kt:19)
        at org.jmailen.gradle.kotlinter.support.KtlintEngineUtilsKt.<clinit>(KtlintEngineUtils.kt:9)
        at org.jmailen.gradle.kotlinter.tasks.format.FormatWorkerAction.execute(FormatWorkerAction.kt:24)
        at org.gradle.workers.internal.DefaultWorkerServer.execute(DefaultWorkerServer.java:63)
        at org.gradle.workers.internal.AbstractClassLoaderWorker$1.create(AbstractClassLoaderWorker.java:54)
        at org.gradle.workers.internal.AbstractClassLoaderWorker$1.create(AbstractClassLoaderWorker.java:48)
        at org.gradle.internal.classloader.ClassLoaderUtils.executeInClassloader(ClassLoaderUtils.java:100)
        at org.gradle.workers.internal.AbstractClassLoaderWorker.executeInClassLoader(AbstractClassLoaderWorker.java:48)
        at org.gradle.workers.internal.IsolatedClassloaderWorker.run(IsolatedClassloaderWorker.java:49)
        at org.gradle.workers.internal.IsolatedClassloaderWorker.run(IsolatedClassloaderWorker.java:30)
        at org.gradle.workers.internal.WorkerDaemonServer.run(WorkerDaemonServer.java:103)
        at org.gradle.workers.internal.WorkerDaemonServer.run(WorkerDaemonServer.java:72)
        at org.gradle.process.internal.worker.request.WorkerAction$1.call(WorkerAction.java:152)
        at org.gradle.process.internal.worker.child.WorkerLogEventListener.withWorkerLoggingProtocol(WorkerLogEventListener.java:41)
        at org.gradle.process.internal.worker.request.WorkerAction.lambda$run$1(WorkerAction.java:149)
        at org.gradle.internal.operations.CurrentBuildOperationRef.with(CurrentBuildOperationRef.java:85)
        at org.gradle.process.internal.worker.request.WorkerAction.run(WorkerAction.java:141)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
        at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
        at org.gradle.internal.remote.internal.hub.MessageHubBackedObjectConnection$DispatchWrapper.dispatch(MessageHubBackedObjectConnection.java:182)
        at org.gradle.internal.remote.internal.hub.MessageHubBackedObjectConnection$DispatchWrapper.dispatch(MessageHubBackedObjectConnection.java:164)
        at org.gradle.internal.remote.internal.hub.MessageHub$Handler.run(MessageHub.java:414)
        at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)
        at org.gradle.internal.concurrent.AbstractManagedExecutor$1.run(AbstractManagedExecutor.java:48)
Caused by: java.lang.ClassNotFoundException: io.github.oshai.kotlinlogging.KotlinLogging
        ... 37 more
``` 

Configuration:

```kotlin
import org.jmailen.gradle.kotlinter.tasks.FormatTask

plugins {
    id("org.jmailen.kotlinter")
}

configureKotlinter()

tasks.register("formatKotlinSources", FormatTask::class.java) {
    description = "Formats specific Kotlin source files"
    group = "Formatting"
    ktlintClasspath.from()
    source(files(providers.systemProperty("kotlin.files").map { it.split(",") }))
}

fun Project.configureKotlinter() {
    configure<KotlinterExtension> {
        ktlintVersion = "1.5.0"
        ignoreFormatFailures = true
        ignoreLintFailures = false
        reporters = arrayOf("plain", "checkstyle")
    }
}
```