### PR TITLE
Fix issue #423: Configure ktlint classpath for custom tasks when no kotlin plugin is applied

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Available on the Gradle Plugins Portal: https://plugins.gradle.org/plugin/org.jm
 
 ```kotlin
 plugins {
-    id("org.jmailen.kotlinter") version "5.0.1"
+    id("org.jmailen.kotlinter") version "5.0.2"
 }
 ```
 
@@ -36,7 +36,7 @@ plugins {
 
 ```groovy
 plugins {
-    id "org.jmailen.kotlinter" version "5.0.1"
+    id "org.jmailen.kotlinter" version "5.0.2"
 }
 ```
 
@@ -50,7 +50,7 @@ Root `build.gradle.kts`
 
 ```kotlin
 plugins {
-    id("org.jmailen.kotlinter") version "5.0.1" apply false
+    id("org.jmailen.kotlinter") version "5.0.2" apply false
 }
 ```
 
@@ -70,7 +70,7 @@ Root `build.gradle`
 
 ```groovy
 plugins {
-    id 'org.jmailen.kotlinter' version "5.0.1" apply false
+    id 'org.jmailen.kotlinter' version "5.0.2" apply false
 }
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,7 @@ val githubUrl = "https://github.com/jeremymailen/kotlinter-gradle"
 val webUrl = "https://github.com/jeremymailen/kotlinter-gradle"
 val projectDescription = "Lint and formatting for Kotlin using ktlint with configuration-free setup on JVM and Android projects"
 
-version = "5.0.1"
+version = "5.0.2"
 group = "org.jmailen.gradle"
 description = projectDescription
 


### PR DESCRIPTION
- Moved task classpath configuration outside of plugin-specific block
- Fixed dependency issues by using individual ktlint dependencies instead of CLI