### PR TITLE
Update version properties file path to prevent conflicts with other plugins

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,9 +65,9 @@ kotlin {
 }
 
 tasks {
-    val generateVersionProperties = register("generateVersionProperties") {
+    val generateKotlinterProperties = register("generateKotlinterProperties") {
         val projectVersion = version
-        val propertiesFile = File(sourceSets.main.get().output.resourcesDir, "version.properties")
+        val propertiesFile = File(sourceSets.main.get().output.resourcesDir, "kotlinter.properties")
         inputs.property("projectVersion", projectVersion)
         outputs.file(propertiesFile)
 
@@ -82,7 +82,7 @@ tasks {
     }
 
     processResources {
-        dependsOn(generateVersionProperties)
+        dependsOn(generateKotlinterProperties)
     }
 
     withType<JavaCompile>().configureEach {

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/support/VersionProperties.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/support/VersionProperties.kt
@@ -6,7 +6,7 @@ val versionProperties by lazy { VersionProperties() }
 
 class VersionProperties : Properties() {
     init {
-        load(this.javaClass.getResourceAsStream("/version.properties"))
+        load(this.javaClass.getResourceAsStream("/kotlinter.properties"))
     }
 
     fun version(): String = getProperty("version")


### PR DESCRIPTION
Unfortunately there seems to be a conflict with the [Compose Screenshot Testing](https://developer.android.com/studio/preview/compose-screenshot-testing#setup) plugin. See related issue here: https://issuetracker.google.com/issues/354408405.

I was able to fix this issue but renaming the `version.properties` file here to `kotlinter.properties`. Which helps isolate changes from other plugins as well.