### PR TITLE
Add Gradle 8.14.3 to integration test matrix

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -90,7 +90,7 @@ jobs:
       matrix:
         gradle: [ current ]
         java: [ 21 ]
-        agp: [7.4.2, 8.5.2, 8.11.1]
+        agp: [7.4.2, 8.5.2, 8.11.1, 8.14.3]
 
     name: '[android] Gradle: ${{ matrix.gradle }}, Java: ${{ matrix.java }}, AGP: ${{ matrix.agp }}'
     steps:


### PR DESCRIPTION
Add an additional Gradle version, 8.14.3 to integration test matrix. 